### PR TITLE
Release 1.2.3

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,22 @@
 Changelog
 =========
 
+.. _v1.2.3:
+
+1.2.3
+=====
+
++ :feature:`47` Added parsing of ranges for ``fragment-offset`` statements in
+  Juniper ACLs.
++ :bug:`49` Changed ACL parser to omit src/dst ports if port range is
+  ``0-65535``.
++ :bug:`50` Fix typo that was causing Cisco parsing to generate an unhandled
+  exception within `~trigger.cmds.NetACLInfo`.
++ Minor bugfix when checking device names and printing a warning within
+  `~trigger.cmds.Commando`.
++ Updated docs to say we're using a interactive Python interpreter and added
+  OpenHatch profile to contact info.
+
 .. _v1.2.2:
 
 1.2.2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -273,6 +273,14 @@ Wiki
 We will use GitHub's built-in wiki located at
 `https://github.com/aol/trigger/wiki <https://github.com/aol/trigger/wiki>`_.
 
+.. _openhatch:
+
+OpenHatch
+---------
+
+Find Trigger on Openhatch at 
+`http://openhatch.org/+projects/Trigger <http://openhatch.org/+projects/Trigger>`_!
+
 .. _license:
 
 License

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 2, 2)
+__version__ = (1, 2, 3)
 
 full_version = '.'.join(str(x) for x in __version__)
 release = full_version

--- a/trigger/acl/parser.py
+++ b/trigger/acl/parser.py
@@ -1311,7 +1311,7 @@ class Matches(MyDict):
             arg = map(do_protocol_lookup, arg)
             check_range(arg, 0, 255)
         elif key == 'fragment-offset':
-            arg = map(int, arg)
+            arg = map(do_port_lookup, arg)
             check_range(arg, 0, 8191)
         elif key == 'icmp-type':
             arg = map(do_icmp_type_lookup, arg)
@@ -1396,6 +1396,9 @@ class Matches(MyDict):
         for port in ports:
             try:
                 if port[0] == 0:
+                    # Omit ports if 0-65535
+                    if port[1] == 65535:
+                        continue
                     a.append('lt %s' % (port[1]+1))
                 elif port[1] == 65535:
                     a.append('gt %s' % (port[0]-1))
@@ -1845,7 +1848,6 @@ keyword_match('destination-address', 'cidr / ipv4')
 keyword_match('destination-prefix-list', 'jword')
 keyword_match('first-fragment')
 keyword_match('fragment-flags', 'fragment_flag')
-keyword_match('fragment-offset', 'digits')
 keyword_match('ip-options', 'ip_option')
 keyword_match('is-fragment')
 keyword_match('prefix-list', 'jword')
@@ -1867,6 +1869,7 @@ range_match('dscp', 'dscp')
 range_match('ether-type', 'alphanums')
 range_match('esp-spi', 'alphanums')
 range_match('forwarding-class', 'jword')
+range_match('fragment-offset', 'port')
 range_match('icmp-code', 'icmp_code')
 range_match('icmp-type', 'icmp_type')
 range_match('interface-group', 'digits')


### PR DESCRIPTION
- Minor bugfix when checking device names and printing warning within
  trigger.cmds.Commando
- Fix typo that was causing Cisco parsing to generate an unhandled
  exception within trigger.cmds.NetACLInfo
- Changed ACL parser to omit src/dst ports if port range is 0-65535
- Added parsing of ranges for 'fragment-offset' statements in Juniper
  ACLs
- Updated docs to say we're using a interactive Python interpreter and
  added OpenHatch profile to contact info
