### PR TITLE
allow running cli

### DIFF
--- a/trigger/gorc.py
+++ b/trigger/gorc.py
@@ -58,7 +58,7 @@ INIT_COMMANDS_SECTION = 'init_commands'
 # out by filter_commands()
 ALLOWED_COMMANDS = (
     'set', 'show', 'get', 'ping', 'traceroute', 'who', 'whoami', 'monitor',
-    'term', 'terminal',
+    'term', 'terminal', 'cli',
 )
 
 


### PR DESCRIPTION
Hello, when first logging into a juniper device into a direct shell, running cli is necessary to get into the command line interface.
