### PR TITLE
Release 1.2.4

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,11 +4,13 @@ Contributors
 The following people have contributed to Trigger at some point during its
 lifetime: 
 
-- Jathan McCollum
+- `Jathan McCollum <https://github.com/jathanism>`_
 - Eileen Tschetter
-- Mark Ellzey Thomas
+- `Mark Ellzey Thomas <https://github.com/ellzey>`_
 - Michael Shields
 - Jeff Sullivan (for the best error message ever)
 - `Nick Sinopoli <https://github.com/NSinopoli>`_ (for graciously giving us the
   name Trigger!)
 - `Jason Long <https://github.com/sh0x>`_
+- `Michael Harding <https://github.com/mvh>`_
+- William White

--- a/bin/load_acl
+++ b/bin/load_acl
@@ -16,7 +16,7 @@ __author__ = 'Jathan McCollum, Eileen Tschetter, Mark Ellzey Thomas, Michael Shi
 __maintainer__ = 'Jathan McCollum'
 __email__ = 'jathan.mccollum@teamaol.com'
 __copyright__ = 'Copyright 2003-2012, AOL Inc.'
-__version__ = '1.7'
+__version__ = '1.8'
 
 # Dist imports
 from collections import defaultdict
@@ -395,13 +395,16 @@ def get_work(opts, args):
 
     return work
 
-def junoscript_cmds(acls):
+def junoscript_cmds(acls, dev):
     """
     Return a list of Junoscript commands to load the given ACLs, and a
     matching list of tuples (acls remaining, human-readable status message).
 
     :param acls:
         A collection of ACL names
+
+    :param dev:
+        A Juniper `~trigger.netdevices.NetDevice` object
     """
     xml = [Element('lock-configuration')]
     status = ['locking configuration']
@@ -413,7 +416,8 @@ def junoscript_cmds(acls):
         xml.append(lc)
         status.append('loading ACL ' + acl)
 
-    xml.append(Element('commit-configuration'))
+    # Add the proper commit command
+    xml.extend(dev.commit_commands)
     status.append('committing for ' + ','.join(acls))
     status.append('done for' + ','.join(acls) )
 
@@ -447,7 +451,9 @@ def ioslike_cmds(acls, dev, nonce):
     template = template_base[dev.vendor.name]
     cmds = [template % (get_tftp_source(dev), acl, nonce) for acl in acls]
     status = ['loading ACL ' + acl for acl in acls]
-    cmds.append('write mem')
+
+    # Add the proper write mem command
+    cmds.extend(dev.commit_commands)
     status.append('saving config for ' + ','.join(acls))
     status.append('done for ' + ','.join(acls))
 
@@ -591,7 +597,7 @@ def activate(work, active, failures, jobs, redraw):
         active[dev] = 'connecting'
 
         if dev.vendor == 'juniper':
-            cmds, status = junoscript_cmds(acls)
+            cmds, status = junoscript_cmds(acls, dev)
             execute = execute_junoscript
         else:
             nonce = os.urandom(8).encode('hex')

--- a/conf/trigger_settings.py
+++ b/conf/trigger_settings.py
@@ -181,6 +181,15 @@ VALID_OWNERS = (
     'Enterprise Networking',
 )
 
+# Fields and values defined here will dictate which Juniper devices receive a#
+# ``commit-configuration full`` when populating ``NetDevice.commit_commands`.#
+# The fields and values must match the objects exactly or it will fallback to
+# ``commit-configuration``.
+JUNIPER_FULL_COMMIT_FIELDS = {
+    'deviceType': 'SWITCH',
+    'make': 'EX4200',
+}
+
 #===============================
 # Redis Settings
 #===============================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,22 @@
 Changelog
 =========
 
+.. _v1.2.4:
+
+1.2.4
+=====
+
++ The commands required to commit/save the configuration on a device are now
+  attached to `~trigger.netdevices.NetDevice` objects under the
+  `~trigger.netdevices.NetDevice.commit_commands` attribute, to make it easier
+  to execute these commands without having to determine them for yourself.
++ :feature:`56` Added a way to optionally perform a ``commit full`` operation
+  on Juniper devices by defining a dictionary of attributes and values for
+  matching devices using :setting:`JUNIPER_FULL_COMMIT_FIELDS`. This modifies
+  the ``commit_commands`` that are assigned when the
+  `~trigger.netdevices.NetDevice` object is created.
++ :bug:`33` Console paging is now disabled by default for async SSH channels.
+
 .. _v1.2.3:
 
 1.2.3

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -476,6 +476,28 @@ Default::
 
     ()
 
+.. setting:: JUNIPER_FULL_COMMIT_FIELDS
+
+JUNIPER_FULL_COMMIT_FIELDS
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Fields and values defined here will dictate which Juniper devices receive a
+``commit-configuration full`` when populating
+`~trigger.netdevices.NetDevice.commit_commands`. The fields and values must
+match the objects exactly or it will fallback to ``commit-configuration``.
+
+Example::
+
+    # Perform "commit full" on all Juniper EX4200 switches.
+    JUNIPER_FULL_COMMIT_FIELDS = {
+        'deviceType': 'SWITCH',
+        'make': 'EX4200',
+    }
+
+Default ::
+
+    {}
+
 Redis settings
 --------------
 

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 2, 3)
+__version__ = (1, 2, 4)
 
 full_version = '.'.join(str(x) for x in __version__)
 release = full_version

--- a/trigger/cmds.py
+++ b/trigger/cmds.py
@@ -531,13 +531,13 @@ class NetACLInfo(Commando):
     def to_cisco(self, dev, commands=None, extra=None):
         """This is the "show me all interface information" command we pass to
         IOS devices"""
-        return ['show  configuration | include ^(interface | ip address | ip access-group | description|!)']
+        return ['show configuration | include ^(interface | ip address | ip access-group | description|!)']
 
     def to_arista(self, dev, commands=None, extra=None):
         """
         Similar to IOS, but:
 
-           + Arista has now "show conf" so we have to do "show run"
+           + Arista has no "show conf" so we have to do "show run"
            + The regex used in the CLI for Arista is more "precise" so we have to change the pattern a little bit compared to the on in generate_ios_cmd
 
         """

--- a/trigger/conf/global_settings.py
+++ b/trigger/conf/global_settings.py
@@ -180,6 +180,15 @@ VALID_OWNERS = (
     #'Enterprise Networking',
 )
 
+# Fields and values defined here will dictate which Juniper devices receive a
+# ``commit-configuration full`` when populating ``NetDevice.commit_commands`.
+# The fields and values must match the objects exactly or it will fallback to
+# ``commit-configuration``.
+JUNIPER_FULL_COMMIT_FIELDS = {
+    #'deviceType': 'SWITCH',
+    #'make': 'EX4200',
+}
+
 #===============================
 # Redis Settings
 #===============================

--- a/trigger/utils/cli.py
+++ b/trigger/utils/cli.py
@@ -32,9 +32,33 @@ def yesno(prompt, default=False, autoyes=False):
     """
     Present a yes-or-no prompt, get input, and return a boolean.
 
-    :param prompt: Prompt text
-    :param default: Yes if True; No if False
-    :param autoyes: Automatically return True
+    The ``default`` argument is ignored if ``autoyes`` is set.
+
+    :param prompt:
+        Prompt text
+
+    :param default:
+        Yes if True; No if False
+
+    :param autoyes:
+        Automatically return True
+
+    Default behavior (hitting "enter" returns ``False``)::
+
+        >>> yesno('Blow up the moon?')
+        Blow up the moon? (y/N)
+        False
+
+    Reversed behavior (hitting "enter" returns ``True``)::
+
+        >>> yesno('Blow up the moon?', default=True)
+        Blow up the moon? (Y/n)
+        True
+
+    Automatically return ``True`` with ``autoyes``; no prompt is displayed::
+
+        >>> yesno('Blow up the moon?', autoyes=True)
+        True
     """
     if autoyes:
         return True
@@ -119,7 +143,8 @@ def pretty_time(t):
     Print a pretty version of timestamp, including timezone info. Expects
     the incoming datetime object to have proper tzinfo.
 
-    :param t: A ``datetime.datetime`` object
+    :param t:
+        A ``datetime.datetime`` object
 
     >>> import datetime
     >>> from pytz import timezone
@@ -153,7 +178,8 @@ def min_sec(secs):
     """
     Takes an epoch timestamp and returns string of minutes:seconds.
 
-    :param secs: Timestamp (in seconds)
+    :param secs:
+        Timestamp (in seconds)
 
     >>> import time 
     >>> start = time.time()  # Wait a few seconds


### PR DESCRIPTION
- The commands required to commit/save the configuration on a device
  are now attached to NetDevice objects under the commit_commands
  attribute, to make it easier to execute these commands without having
  to determine them for yourself.
- Added a way to optionally perform a "commit full" operation on
  Juniper devices by defining a dictionary of attributes and values for
  matching devices using settings.JUNIPER_FULL_COMMIT_FIELDS. This
  modifies the commit_commands that are assigned when the NetDevice
  object is created.
- Console paging is now disabled by default for async SSH channels.
