### PR TITLE
Trigger 1.3 crashing on Telnet connections

### DIFF
--- a/trigger/twister.py
+++ b/trigger/twister.py
@@ -1429,6 +1429,8 @@ class TriggerTelnet(telnet.Telnet, telnet.ProtocolTransportMixin, TimeoutMixin):
 
     def login_state_machine(self, bytes):
         """Track user login state."""
+        self.host = self.transport.connector.host
+        log.msg('CONNECTOR HOST: ', self.transport.connector.host)
         self.data += bytes
         log.msg('STATE:  got data %r' % self.data, debug=True)
         for (text, next_state) in self.waiting_for:
@@ -1483,8 +1485,6 @@ class TriggerTelnet(telnet.Telnet, telnet.ProtocolTransportMixin, TimeoutMixin):
         action.loseConnection = self.loseConnection
         action.connectionMade()
         action.dataReceived(data)
-
-        self.host = self.transport.connector.host
 
     def state_enable(self):
         """


### PR DESCRIPTION
Looks like we introduced a nice new bug w/ telnet:

```
Fetching credentials from /home/jathan/.tacacsrc
Unhandled Error
Traceback (most recent call last):
  File "/usr/local/lib/python/site-packages/twisted/python/log.py", line 84, in callWithLogger
    return callWithContext({"system": lp}, func, *args, **kw)
  File "/usr/local/lib/python/site-packages/twisted/python/log.py", line 69, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File "/usr/local/lib/python/site-packages/twisted/python/context.py", line 118, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/usr/local/lib/python/site-packages/twisted/python/context.py", line 81, in callWithContext
    return func(*args,**kw)
--- <exception caught here> ---
  File "/usr/local/lib/python/site-packages/twisted/internet/posixbase.py", line 586, in _doReadOrWrite
    why = selectable.doRead()
  File "/usr/local/lib/python/site-packages/twisted/internet/tcp.py", line 199, in doRead
    rval = self.protocol.dataReceived(data)
  File "/usr/local/lib/python/site-packages/twisted/conch/telnet.py", line 588, in dataReceived
    self.applicationDataReceived(''.join(appDataBuffer))
  File "/usr/local/lib/python/site-packages/trigger/twister.py", line 1439, in login_state_machine
    next_state()
  File "/usr/local/lib/python/site-packages/trigger/twister.py", line 1508, in state_login_pw
    pw = NetDevices().find(self.host).loginPW
exceptions.AttributeError: TriggerTelnet instance has no attribute 'host'
```
