### PR TITLE
Add support for F5 Big/IP devices

### DIFF
--- a/conf/trigger_settings.py
+++ b/conf/trigger_settings.py
@@ -54,6 +54,7 @@ SUPPORTED_VENDORS = (
     'cisco',
     'citrix',
     'dell',
+    'f5',
     'force10',
     'foundry',
     'juniper',
@@ -76,6 +77,7 @@ VENDOR_MAP = {
     'CISCO SYSTEMS': 'cisco',
     'CITRIX': 'citrix',
     'DELL': 'dell',
+    'F5 NETWORKS': 'f5',
     'FORCE10': 'force10',
     'FOUNDRY': 'foundry',
     'JUNIPER': 'juniper',
@@ -92,6 +94,7 @@ SUPPORTED_PLATFORMS = {
     'cisco': ['ROUTER', 'SWITCH'],
     'citrix': ['SWITCH'],                         # Assumed to be NetScalers
     'dell': ['SWITCH'],
+    'f5': ['LOAD BALANCING', 'SWITCH'],
     'force10': ['ROUTER', 'SWITCH'],
     'foundry': ['ROUTER', 'SWITCH'],
     'juniper': ['FIREWALL', 'ROUTER', 'SWITCH'],  # Any devices running Junos
@@ -101,7 +104,7 @@ SUPPORTED_PLATFORMS = {
 }
 
 # The tuple of support device types
-SUPPORTED_TYPES = ('CONSOLE SERVER', 'FIREWALL', 'DWDM', 'LOAD BALANCER',
+SUPPORTED_TYPES = ('CONSOLE SERVER', 'FIREWALL', 'DWDM', 'LOAD BALANCING',
                    'ROUTER', 'SWITCH')
 
 # A mapping of of vendor names to the default device type for each in the
@@ -114,6 +117,7 @@ DEFAULT_TYPES = {
     'citrix': 'SWITCH',
     'cisco': 'ROUTER',
     'dell': 'SWITCH',
+    'f5': 'LOAD BALANCING',
     'force10': 'ROUTER',
     'foundry': 'SWITCH',
     'juniper': 'ROUTER',
@@ -250,6 +254,7 @@ JUNIPER_FULL_COMMIT_FIELDS = {
 PROMPT_PATTERNS = {
     'aruba': r'\(\S+\)(?: \(\S+\))?\s?#',
     'citrix': r'\sDone\n$',
+    'f5': r'(?:\S+\@)?\S+(?:\(.*\))\(tmos\)#\s{1,2}\r?$',
     'juniper': r'\S+\@\S+(?:\>|#)\s$',
     'mrv': r'\r\n?.*(?:\:\d{1})?\s\>\>?$',
     'netscreen': r'(\w+?:|)[\w().-]*\(?([\w.-])?\)?\s*->\s*$',

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 4, 1, 'b1')
+__version__ = (1, 4, 1, 'b2')
 
 full_version = '.'.join(map(str, __version__[0:3])) + ''.join(__version__[3:])
 release = full_version

--- a/trigger/conf/global_settings.py
+++ b/trigger/conf/global_settings.py
@@ -67,6 +67,7 @@ SUPPORTED_VENDORS = (
     'cisco',
     'citrix',
     'dell',
+    'f5',
     'force10',
     'foundry',
     'juniper',
@@ -90,6 +91,7 @@ VENDOR_MAP = {
     'CISCO SYSTEMS': 'cisco',
     'CITRIX': 'citrix',
     'DELL': 'dell',
+    'F5 NETWORKS': 'f5',
     'FORCE10': 'force10',
     'FOUNDRY': 'foundry',
     'JUNIPER': 'juniper',
@@ -107,6 +109,7 @@ SUPPORTED_PLATFORMS = {
     'cisco': ['ROUTER', 'SWITCH'],
     'citrix': ['SWITCH'],                         # Assumed to be NetScalers
     'dell': ['SWITCH'],
+    'f5': ['LOAD BALANCING', 'SWITCH'],
     'force10': ['ROUTER', 'SWITCH'],
     'foundry': ['ROUTER', 'SWITCH'],
     'juniper': ['FIREWALL', 'ROUTER', 'SWITCH'],  # Any devices running Junos
@@ -116,7 +119,8 @@ SUPPORTED_PLATFORMS = {
 }
 
 # The tuple of support device types
-SUPPORTED_TYPES = ('CONSOLE SERVER', 'FIREWALL', 'DWDM', 'LOAD BALANCER', 'ROUTER', 'SWITCH')
+SUPPORTED_TYPES = ('CONSOLE SERVER', 'FIREWALL', 'DWDM', 'LOAD BALANCING',
+                   'ROUTER', 'SWITCH')
 
 # A mapping of of vendor names to the default device type for each in the
 # event that a device object is created and the deviceType attribute isn't set
@@ -267,6 +271,7 @@ JUNIPER_FULL_COMMIT_FIELDS = {
 PROMPT_PATTERNS = {
     'aruba': r'\(\S+\)(?: \(\S+\))?\s?#',
     'citrix': r'\sDone\n$',
+    'f5': r'(?:\S+\@)?\S+(?:\(.*\))\(tmos\)#\s{1,2}\r?$',
     'juniper': r'\S+\@\S+(?:\>|#)\s$',
     'mrv': r'\r\n?.*(?:\:\d{1})?\s\>\>?$',
     'netscreen': r'(\w+?:|)[\w().-]*\(?([\w.-])?\)?\s*->\s*$',

--- a/trigger/netdevices/__init__.py
+++ b/trigger/netdevices/__init__.py
@@ -306,6 +306,7 @@ class NetDevice(object):
             'brocade': disable_paging_brocade(), # See comments above
             'cisco': default,
             'dell': ['terminal datadump\n'],
+            'f5': ['modify cli preference pager disabled\n'],
             'force10': default,
             'foundry': ['skip-page-display\n'],
             'juniper': ['set cli screen-length 0\n'],
@@ -333,6 +334,8 @@ class NetDevice(object):
             return ['commit']
         elif self.vendor == 'mrv':
             return ['save configuration flash']
+        elif self.vendor == 'f5':
+            return ['save sys config']
         else:
             return []
 

--- a/trigger/twister.py
+++ b/trigger/twister.py
@@ -75,7 +75,7 @@ def has_ioslike_error(s):
     tests = (
         s.startswith('%'),                 # Cisco, Arista
         '\n%' in s,                        # A10, Aruba, Foundry
-        'syntax error: ' in s,             # Brocade VDX
+        'syntax error: ' in s.lower(),     # Brocade VDX, F5 BIGIP
         s.startswith('Invalid input -> '), # Brocade MLX
         s.endswith('Syntax Error'),        # MRV
     )


### PR DESCRIPTION
Both SSH (CLI) and iControl API should be supported.
# iControl References

Python iControl library
https://devcentral.f5.com/community/group/asg/4

Code samples (requires login):
https://devcentral.f5.com/wiki/icontrol.pycontrol_v2.ashx

iControl white paper:
http://www.f5.com/pdf/white-papers/icontrol-wp.pdf
