### PR TITLE
bin/optimizer crash NameError

### DIFF
--- a/bin/optimizer
+++ b/bin/optimizer
@@ -498,7 +498,7 @@ def optimize(opts, terms, focused):
 
     chunks = terms_chunker(terms)
 
-    for type in types:
+    for type in mtypes:
         if stop_all:
             return terms
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/opt/bin/optimizer", line 618, in <module>
    do_work(opts, acl_files)
  File "/opt/bin/optimizer", line 562, in do_work
    terms = optimize(opts, terms_old, focused)
  File "/opt/bin/optimizer", line 501, in optimize
    for type in types:
NameError: global name 'types' is not defined
