### PR TITLE
TriggerTelnetClientFactory was missing device attribute

### DIFF
--- a/trigger/twister.py
+++ b/trigger/twister.py
@@ -1735,7 +1735,7 @@ class IoslikeSendExpect(protocol.Protocol, TimeoutMixin):
                 next_init = self.startup_commands.pop(0)
                 log.msg('[%s] Sending initialize command: %r' % (self.device,
                                                                  next_init))
-                self.write(next_init)
+                self.write(next_init.strip() + self.device.delimiter)
                 return None
             else:
                 log.msg('[%s] Successfully initialized for command execution' %
@@ -1758,7 +1758,7 @@ class IoslikeSendExpect(protocol.Protocol, TimeoutMixin):
             self._send_next()
         else:
             log.msg('[%s] Sending command %r' % (self.device, next_command))
-            self.write(next_command + '\n')
+            self.write(next_command + self.device.delimiter)
 
     def timeoutConnection(self):
         """Do this when we timeout."""


### PR DESCRIPTION
gong fallback from SSH to telnet is broken in current revision of develop branch:

```
[nms@test-network trigger]$ gong c1941
Connecting to c1941.  Use ^X to exit.

Fetching credentials from /home/nms/.tacacsrc
Unhandled Error
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/twisted/python/log.py", line 88, in callWithLogger
    return callWithContext({"system": lp}, func, *args, **kw)
  File "/usr/lib/python2.6/site-packages/twisted/python/log.py", line 73, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File "/usr/lib/python2.6/site-packages/twisted/python/context.py", line 118, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/usr/lib/python2.6/site-packages/twisted/python/context.py", line 81, in callWithContext
    return func(*args,**kw)
--- <exception caught here> ---
  File "/usr/lib/python2.6/site-packages/twisted/internet/posixbase.py", line 614, in _doReadOrWrite
    why = selectable.doRead()
  File "/usr/lib/python2.6/site-packages/twisted/internet/tcp.py", line 215, in doRead
    return self._dataReceived(data)
  File "/usr/lib/python2.6/site-packages/twisted/internet/tcp.py", line 221, in _dataReceived
    rval = self.protocol.dataReceived(data)
  File "/usr/lib/python2.6/site-packages/twisted/conch/telnet.py", line 588, in dataReceived
    self.applicationDataReceived(''.join(appDataBuffer))
  File "build/bdist.linux-i686/egg/trigger/twister.py", line 1536, in login_state_machine

  File "build/bdist.linux-i686/egg/trigger/twister.py", line 1581, in state_logged_in

  File "build/bdist.linux-i686/egg/trigger/twister.py", line 1007, in connectionMade

exceptions.AttributeError: 'TriggerTelnetClientFactory' object has no attribute 'device'
```

Also, there are delimiters missing while sending commands in IoslikeSendExpect class.
