### PR TITLE
Add support for alternate remote ports.

### DIFF
--- a/conf/trigger_settings.py
+++ b/conf/trigger_settings.py
@@ -148,6 +148,12 @@ TELNET_TIMEOUT  = 60
 # Whether or not to allow telnet fallback
 TELNET_ENABLED = True
 
+# Default ports for SSH
+SSH_PORT = 22
+
+# Default port for Telnet
+TELNET_PORT = 23
+
 # A mapping of vendors to the types of devices for that vendor for which you
 # would like to disable interactive (pty) SSH sessions, such as when using
 # bin/gong.

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -360,6 +360,32 @@ Default::
 
     True
 
+.. setting:: SSH_PORT
+
+SSH_PORT
+~~~~~~~~
+
+.. versionadded:: 1.4.4
+
+Destination TCP port to use for SSH client connections.
+
+Default::
+
+    22
+
+.. setting:: TELNET_PORT
+
+TELNET_PORT
+~~~~~~~~~~~
+
+.. versionadded:: 1.4.4
+
+Destination TCP port to use for Telnet client connections.
+
+Default::
+
+    23
+
 .. setting:: TRIGGER_ENABLEPW
 
 TRIGGER_ENABLEPW

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 4, 3)
+__version__ = (1, 4, 3, 'r6')
 
 full_version = '.'.join(map(str, __version__[0:3])) + ''.join(__version__[3:])
 release = full_version

--- a/trigger/conf/global_settings.py
+++ b/trigger/conf/global_settings.py
@@ -160,6 +160,12 @@ TELNET_TIMEOUT  = 60
 # Whether or not to allow telnet fallback
 TELNET_ENABLED = True
 
+# Default ports for SSH
+SSH_PORT = 22
+
+# Default port for Telnet
+TELNET_PORT = 23
+
 # A mapping of vendors to the types of devices for that vendor for which you
 # would like to disable interactive (pty) SSH sessions, such as when using
 # bin/gong.

--- a/trigger/twister.py
+++ b/trigger/twister.py
@@ -9,6 +9,7 @@ __author__ = 'Jathan McCollum, Eileen Tschetter, Mark Thomas, Michael Shields'
 __maintainer__ = 'Jathan McCollum'
 __email__ = 'jathan.mccollum@teamaol.com'
 __copyright__ = 'Copyright 2006-2013, AOL Inc.; 2013 Salesforce.com'
+__version__ = '1.5.6'
 
 import copy
 import fcntl
@@ -208,8 +209,8 @@ def pty_connect(device, action, creds=None, display_banner=None,
 
         factory = TriggerSSHPtyClientFactory(d, action, creds, display_banner,
                                              init_commands, device=device)
-        log.msg('Trying SSH to %s' % device, debug=True)
-        port = 22
+        port = device.nodePort or settings.SSH_PORT
+        log.msg('Trying SSH to %s:%s' % (device, port), debug=True)
 
     # or Telnet?
     elif settings.TELNET_ENABLED:
@@ -217,8 +218,8 @@ def pty_connect(device, action, creds=None, display_banner=None,
                 device)
         factory = TriggerTelnetClientFactory(d, action, creds,
                                              init_commands=init_commands, device=device)
-        log.msg('Trying telnet to %s' % device, debug=True)
-        port = 23
+        port = device.nodePort or settings.TELNET_PORT
+        log.msg('Trying telnet to %s:%s' % (device, port), debug=True)
     else:
         log.msg('[%s] SSH connection test FAILED, telnet fallback disabled' % device)
         return None
@@ -436,8 +437,9 @@ def execute_generic_ssh(device, commands, creds=None, incremental=None,
                                        command_interval, prompt_pattern,
                                        device, connection_class)
 
-    log.msg('Trying %s SSH to %s' % (method, device), debug=True)
-    reactor.connectTCP(device.nodeName, 22, factory)
+    port = device.nodePort or settings.SSH_PORT
+    log.msg('Trying %s SSH to %s:%s' % (method, device, port), debug=True)
+    reactor.connectTCP(device.nodeName, port, factory)
     return d
 
 def execute_exec_ssh(device, commands, creds=None, incremental=None,
@@ -534,8 +536,9 @@ def execute_ioslike_telnet(device, commands, creds=None, incremental=None,
                                timeout, command_interval)
     factory = TriggerTelnetClientFactory(d, action, creds, loginpw, enablepw)
 
-    log.msg('Trying IOS-like scripting to %s' % device, debug=True)
-    reactor.connectTCP(device.nodeName, 23, factory)
+    port = device.nodePort or settings.TELNET_PORT
+    log.msg('Trying IOS-like scripting to %s:%s' % (device, port), debug=True)
+    reactor.connectTCP(device.nodeName, port, factory)
     return d
 
 def execute_async_pty_ssh(device, commands, creds=None, incremental=None,

--- a/trigger/utils/__init__.py
+++ b/trigger/utils/__init__.py
@@ -62,3 +62,17 @@ def strip_juniper_namespace(path, key, value):
         key = key.replace(ns, '')
 
     return JuniperElement(key, value)
+
+NodePort = namedtuple('HostPort', 'nodeName nodePort')
+def parse_node_port(nodeport, delimiter=':'):
+    """
+    Parse a string in format 'hostname' or 'hostname:port'  and return them
+    as a 2-tuple.
+    """
+    node, _, port = nodeport.partition(delimiter)
+    if port.isdigit():
+        port = int(port)
+    else:
+        port = None
+
+    return NodePort(str(node), port)


### PR DESCRIPTION
This is working but needs to be documented before we can merge it in. The new settings are documented, but need to document how one would configure a device to have a remote port in one of two ways:
1. "hostname:port" in the hostname field either in the CSV, XML, or JSON, or SQLite formats (this will break w/ RANCID since it's already colon-separated).
2. In XML, JSON, or SQLite formats, you may specify a "nodePort" attribute with a numeric port value.
