### PR TITLE
Adding confirmation prompt support to TriggerSSHChannelBase.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,17 @@
 Changelog
 =========
 
+.. _v1.4.3r2:
+
+1.4.3r2
+=======
+
+Enhancements
+------------
+
++ Added SSH support for confirmation prompts
++ Added '[confirm]' as one of those prompts
+
 .. _v1.4.3:
 
 1.4.3

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 4, 3, 'r1')
+__version__ = (1, 4, 3, 'r2')
 
 full_version = '.'.join(map(str, __version__[0:3])) + ''.join(__version__[3:])
 release = full_version


### PR DESCRIPTION
- These prompts were already supported within Telnet sessions. They need
  to be supported with SSH too.
- Added [confirm] as an additional confirmation prompt to match
