### PR TITLE
Support for Cisco's ASA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ _build
 
 # Gerrit
 .gitreview
+
+# PyCharm
+.idea

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,3 +18,4 @@ lifetime:
 - `Mike Biancaniello <https://github.com/chepazzo>`_
 - `Murat Ezbiderli <https://github.com/mezbiderli>`_
 - `Johannes Erdfelt <https://github.com/jerdfelt>`_
+- `Codey Oxley <https://github.com/coxley>`_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,33 @@
 Changelog
 =========
 
+.. _v1.4.8:
+
+1.4.8
+=====
+
+New Features
+------------
+
++ Cisco ASA firewall now supported as a NetDevice. To begin using, ensure
+  that 'FIREWALL' is added in your settings.py as a supported cisco platform.o
+
+  For it to enable properly, either the netdevice attribute enablePW needs
+  to be set or the environment variable TRIGGER_ENABLEPW does. For now, I
+  typically accomplish this via::
+
+      >>> from trigger.conf import settings
+      >>> from trigger import tacacsrc
+      >>> settings.DEFAULT_REALM = 'MyRealm'
+      >>> os.environ['TRIGGER_ENABLEPW'] = \
+              tacacsrc.get_device_password(settings.DEFAULT_REALM).password
+      >>> # Then the rest of my program
+
+  ACL parsing for ASA is not implemented yet. NetACLInfo will generate the
+  proper command, but will currently just add a message warning about future
+  support
+
+
 .. _v1.4.7:
 
 1.4.7

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,10 +11,10 @@ New Features
 ------------
 
 + Cisco ASA firewall now supported as a NetDevice. To begin using, ensure
-  that 'FIREWALL' is added in your settings.py as a supported cisco platform.o
+  that ``FIREWALL`` is added in your settings.py as a supported cisco platform.o
 
-  For it to enable properly, either the netdevice attribute enablePW needs
-  to be set or the environment variable TRIGGER_ENABLEPW does. For now, I
+  For it to enable properly, either the netdevice attribute ``enablePW`` needs
+  to be set or the environment variable ``TRIGGER_ENABLEPW`` does. For now, I
   typically accomplish this via::
 
       >>> from trigger.conf import settings

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 4, 7)
+__version__ = (1, 4, 8)
 
 full_version = '.'.join(map(str, __version__[0:3])) + ''.join(__version__[3:])
 release = full_version

--- a/trigger/cmds.py
+++ b/trigger/cmds.py
@@ -679,7 +679,10 @@ class NetACLInfo(Commando):
     def to_cisco(self, dev, commands=None, extra=None):
         """This is the "show me all interface information" command we pass to
         IOS devices"""
-        return ['show configuration | include ^(interface | ip address | ip access-group | description|!)']
+        if dev.is_cisco_asa():
+            return ['show running-config | include ^(interface | ip address | nameif | description |access-group|!)']
+        else:
+            return ['show configuration | include ^(interface | ip address | ip access-group | description|!)']
 
     def to_arista(self, dev, commands=None, extra=None):
         """

--- a/trigger/cmds.py
+++ b/trigger/cmds.py
@@ -295,6 +295,9 @@ class Commando(object):
             from_juniper
             to_foundry
 
+        and defaults to ``self.from_base`` and ``self.to_base`` methods if
+        customized methods not found.
+
         :param device:
             A `~trigger.netdevices.NetDevice` object
 
@@ -360,13 +363,16 @@ class Commando(object):
 
     def parse(self, results, device):
         """
-        Parse output from a device.
+        Parse output from a device. Calls to ``self._lookup_method`` to find
+        specific ``from`` method.
 
         Define a 'from_{vendor_name}' method to customize the behavior for each
         platform.
 
         :param results:
             The results of the commands executed on the device
+        :type results:
+            list
 
         :param device:
             A `~trigger.netdevices.NetDevice` object
@@ -715,7 +721,12 @@ class NetACLInfo(Commando):
         alld = data[0]
 
         log.msg('Parsing interface data (%d bytes)' % len(alld))
-        self.config[device] = _parse_ios_interfaces(alld, skip_disabled=self.skip_disabled)
+        if not device.is_cisco_asa():
+            self.config[device] = _parse_ios_interfaces(alld, skip_disabled=self.skip_disabled)
+        else:
+            self.config[device] = {
+                    "unsupported": "ASA ACL parsing unsupported this release"
+                    }
 
         return True
 

--- a/trigger/conf/global_settings.py
+++ b/trigger/conf/global_settings.py
@@ -112,7 +112,7 @@ SUPPORTED_PLATFORMS = {
     'arista': ['SWITCH'],                         # Your "Cloud" network vendor
     'aruba': ['SWITCH'],                          # Aruba Wi-Fi controllers
     'brocade': ['ROUTER', 'SWITCH'],
-    'cisco': ['ROUTER', 'SWITCH'],
+    'cisco': ['ROUTER', 'SWITCH', 'FIREWALL'],
     'citrix': ['SWITCH'],                         # Assumed to be NetScalers
     'dell': ['SWITCH'],
     'f5': ['LOAD BALANCING', 'SWITCH'],

--- a/trigger/netdevices/__init__.py
+++ b/trigger/netdevices/__init__.py
@@ -574,6 +574,11 @@ class NetDevice(object):
         may be used between Cisco's ASA and IOS platforms. Cisco ASA is still
         very IOS-like, but there are still several gotcha's between the
         platforms.
+
+        Will return True if vendor is Cisco and platform is Firewall. This
+        is to allow operability if using .csv NetDevices and pretty safe to
+        assume considering ASA (was PIX) are Cisco's flagship(if not only)
+        Firewalls.
         """
         if hasattr(self, '_is_cisco_asa'):
             return self._is_cisco_asa
@@ -584,6 +589,8 @@ class NetDevice(object):
 
         if self.make is not None:
             self._is_cisco_asa = 'asa' in self.make.lower()
+
+        self._is_cisco_asa = self.vendor == 'cisco' and self.is_firewall()
 
         return self._is_cisco_asa
 

--- a/trigger/netdevices/__init__.py
+++ b/trigger/netdevices/__init__.py
@@ -22,7 +22,7 @@ Example::
 
 """
 
-__author__ = 'Jathan McCollum, Eileen Tschetter, Mark Thomas, Michael Shields'
+__author__ = 'Jathan McCollum, Eileen Tschetter, Mark Thomas, Michael Shields, Codey Oxley'
 __maintainer__ = 'Jathan McCollum'
 __email__ = 'jathan.mccollum@teamaol.com'
 __copyright__ = 'Copyright 2006-2013, AOL Inc.; 2013 Salesforce.com'
@@ -343,6 +343,13 @@ class NetDevice(object):
             else:
                 return ['skip-page-display']
 
+        def disable_paging_cisco():
+            """Cisco ASA commands differ from IOS"""
+            if self.is_cisco_asa():
+                return ['terminal pager 0']
+            else:
+                return default
+
         # Commands used to disable paging.
         default = ['terminal length 0']
         paging_map = {
@@ -350,7 +357,7 @@ class NetDevice(object):
             'arista': default,
             'aruba': ['no paging'], # v6.2.x this is not necessary
             'brocade': disable_paging_brocade(), # See comments above
-            'cisco': default,
+            'cisco': disable_paging_cisco(),
             'dell': ['terminal datadump'],
             'f5': ['modify cli preference pager disabled'],
             'force10': default,
@@ -558,6 +565,28 @@ class NetDevice(object):
         if self.make is not None:
             self._is_brocade_vdx = 'vdx' in self.make.lower()
         return self._is_brocade_vdx
+
+    def is_cisco_asa(self):
+        """
+        Am I a Cisco ASA Firewall?
+
+        This is used to account for slight differences in the commands that
+        may be used between Cisco's ASA and IOS platforms. Cisco ASA is still
+        very IOS-like, but there are still several gotcha's between the
+        platforms.
+        """
+        if hasattr(self, '_is_cisco_asa'):
+            return self._is_cisco_asa
+
+        if not (self.vendor == 'cisco' and self.is_firewall()):
+            self._is_cisco_asa = False
+            return False
+
+        if self.make is not None:
+            self._is_cisco_asa = 'asa' in self.make.lower()
+
+        return self._is_cisco_asa
+
 
     def _ssh_enabled(self, disabled_mapping):
         """Check whether vendor/type is enabled against the given mapping."""

--- a/trigger/netdevices/__init__.py
+++ b/trigger/netdevices/__init__.py
@@ -22,7 +22,7 @@ Example::
 
 """
 
-__author__ = 'Jathan McCollum, Eileen Tschetter, Mark Thomas, Michael Shields, Codey Oxley'
+__author__ = 'Jathan McCollum, Eileen Tschetter, Mark Thomas, Michael Shields'
 __maintainer__ = 'Jathan McCollum'
 __email__ = 'jathan.mccollum@teamaol.com'
 __copyright__ = 'Copyright 2006-2013, AOL Inc.; 2013 Salesforce.com'

--- a/trigger/twister.py
+++ b/trigger/twister.py
@@ -1043,6 +1043,12 @@ class Interactor(protocol.Protocol):
 
     def dataReceived(self, data):
         """And write data to the terminal."""
+        # -- Left during debugging. Enable on ASA not fixed here yet -- #
+        # log.msg('[%s] DATA: %r' % (self.device, data))
+        # if requires_enable(self, data):
+        #     log.msg('[%s] Device Requires Enable: %s' % (self.device, requires_enable(self, data)))
+        #     log.msg('[%s] Is Device Currently Enabled: %s' % (self.device, self.enabled))
+
         # Check whether we need to send an enable password.
         if not self.enabled and requires_enable(self, data):
             log.msg('[%s] Interactive PTY requires enable commands' % self.device)


### PR DESCRIPTION
#### COMMIT

NetDevice + Pager command support. Methods added: is_cisco_asa() disable_paging_cisco()
NetACLInfo: Fixed to_cisco() to modify commands required for ASA.

TODO: Add from_cisco_asa() method and use pyparsing to parse output.

#### DESCRIPTION

This is a pull request to add ASA support. More needs done on the front of full support. Currently it is supported via NetDevices but nethier NetACLInfo or ACL parsing work with ASA.

Will need to also add unit tests before commit is pulled.
