### PR TITLE
run_cmds shouldn't hide error messages (such as command timeouts)

### DIFF
--- a/trigger/contrib/docommand/__init__.py
+++ b/trigger/contrib/docommand/__init__.py
@@ -12,7 +12,7 @@ __author__ = 'Jathan McCollum, Mike Biancianello'
 __maintainer__ = 'Jathan McCollum'
 __email__ = 'jathan@gmail.com'
 __copyright__ = 'Copyright 2012-2013, AOL Inc.; 2013 Salesforce.com'
-__version__ = '3.1'
+__version__ = '3.2'
 
 
 # Imports
@@ -41,10 +41,16 @@ class DoCommandBase(Commando):
     """
     description = 'Insert description here.'
 
+    def errback(self, failure, device):
+        failure = super(DoCommandBase, self).errback(failure, device)
+        print '%s - Error: %s' % (device, failure.value)
+        return failure
+
     def from_base(self, results, device, commands=None):
         """Call store_results without calling map_results"""
         log.msg('Received %r from %s' % (results, device))
         self.store_results(device, results)
+
 
 # TODO: Right now if you are loading commands from files, this will ultimately
 # fail with a ReactorNotRestartable error because the core.main() function is
@@ -160,6 +166,7 @@ class CommandRunner(DoCommandBase):
                 ET.dump(xml)
         self.data[devname] = outs
         return True
+
 
 class ConfigLoader(Commando):
     """
@@ -355,4 +362,3 @@ def xml_print(xml, iterations=10):
             # Show elements in a tag1 -> tag2 -> tag3 -> field:value format
             #ret.append(tag+" -> "+t)
     return ret
-


### PR DESCRIPTION
Currently if command execution fails on a device, you don't get any output, which makes it very hard to identify why it failed!

<!---
@huboard:{"order":4.72265625,"milestone_order":177,"custom_state":""}
-->
