### PR TITLE
Fixing path reference in contrib/docommand/core.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,19 @@ With the high number of network devices on the AOL network this application is
 invaluable to performance and reliability. We hope you'll find it useful on
 your network and consider participating!
 
+Supported Platforms
+===================
+
+* Cisco IOS, NX-OS, and ASA software
+* Juniper Junos and ScreenOS
+* Force10 router and switch platforms running FTOS
+* Arista Networks 7000-family switches
+* ... and more!
+
+Refer to the `official docs`_ for the full list.
+
+.. _official docs: http://trigger.readthedocs.org/en/latest/#supported-platforms
+
 Key Features
 ============
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ vendors:
 + Cisco Systems
 
   - All router and switch platforms running IOS
+  - All firewalls running ASA software (NetACLInfo not implemented)
   - All switch platforms running NX-OS
 
 + Dell

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -245,7 +245,7 @@ Default::
         'a10': ['SWITCH'],
         'arista': ['SWITCH'],
         'brocade': ['ROUTER', 'SWITCH'],
-        'cisco': ['ROUTER', 'SWITCH'],
+        'cisco': ['ROUTER', 'SWITCH', 'FIREWALL'],
         'citrix': ['SWITCH'],
         'dell': ['SWITCH'],
         'foundry': ['ROUTER', 'SWITCH'],

--- a/tests/acceptance/data/settings.py
+++ b/tests/acceptance/data/settings.py
@@ -81,7 +81,7 @@ SUPPORTED_PLATFORMS = {
     'a10': ['SWITCH'],
     'arista': ['SWITCH'],                         # Your "Cloud" network vendor
     'brocade': ['ROUTER', 'SWITCH'],
-    'cisco': ['ROUTER', 'SWITCH'],
+    'cisco': ['FIREWALL', 'ROUTER', 'SWITCH'],
     'citrix': ['SWITCH'],                         # Assumed to be NetScalers
     'dell': ['SWITCH'],
     'foundry': ['ROUTER', 'SWITCH'],

--- a/trigger/contrib/docommand/core.py
+++ b/trigger/contrib/docommand/core.py
@@ -426,7 +426,7 @@ def verify_opts(opts):
     isp = opts.device_path is not None
     if isp:
         if not os.path.isdir(opts.device_path):
-            return False, 'ERROR: %r is not a valid path\n' % path
+            return False, 'ERROR: %r is not a valid directory\n' % opts.device_path
         else:
             return True, ''
     elif isdf or iscf or isd or isc:


### PR DESCRIPTION
Pretty simple fix and also added a clearer error msg.

Feel ashamed, but I made it go past the 79 column mark. Didn't want to really skip it to the next line and there are many other lines in the file that are worse offenders. :'(

Not a fan of how a lot of misuse results in large tracebacks for pretty standard things. For example, `run_cmds -p cool_stuff` will puke out the below if just one thing in the directory isn't a file. Probably a big undertaking time-wise to just try out all the different cases and filter through vs. adding real features/fixing bigger problems.

```pytb
/home/codey/docs/envs/trigger/lib/python2.7/site-packages/trigger/conf/__init__.py:84: RuntimeWarning: Module could not be imported from /etc/trigger/settings.py. Using default global settings.
  warnings.warn(str(err) + ' Using default global settings.', RuntimeWarning)
/home/codey/docs/envs/trigger/lib/python2.7/site-packages/trigger/changemgmt/bounce.py:44: RuntimeWarning: Bounce mappings could not be found in /etc/trigger/bounce.py. using default!
  warnings.warn(msg, RuntimeWarning)
/home/codey/docs/envs/trigger/lib/python2.7/site-packages/trigger/acl/autoacl.py:47: RuntimeWarning: Function autoacl() could not be found in /etc/trigger/autoacl.py, using default!
  warnings.warn(msg, RuntimeWarning)
Traceback (most recent call last):
  File "/home/codey/docs/envs/trigger/bin/run_cmds", line 10, in <module>
    docommand.main(action_class=docommand.CommandRunner)
  File "/home/codey/docs/envs/trigger/lib/python2.7/site-packages/trigger/contrib/docommand/core.py", line 90, in main
    results = do_work(work, action_class)
  File "/home/codey/docs/envs/trigger/lib/python2.7/site-packages/trigger/contrib/docommand/core.py", line 249, in do_work
    debug=DEBUG, timeout=TIMEOUT, production_only=PROD_ONLY)
  File "/home/codey/docs/envs/trigger/lib/python2.7/site-packages/trigger/contrib/docommand/__init__.py", line 102, in __init__
    self.__loadCmdsFromFiles()
  File "/home/codey/docs/envs/trigger/lib/python2.7/site-packages/trigger/contrib/docommand/__init__.py", line 117, in __loadCmdsFromFiles
    with open(fname, 'r') as fr:
IOError: [Errno 21] Is a directory: 'docs/projects'
```

Also, Pygments has support for highlighting Python stack traces? Whaaat.