### PR TITLE
Fix AttributeError for NetDevices.match() when attr val is None.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,8 +13,10 @@ Bug Fixes
 + Bugfix when using `~trigger.netdevices.NetDevices.match()` to lookup devices
   by attribute/value, which will no longer result in a `KeyError` if any device
   is missing the desired attribute. This means that besides the minimum
-  required attributes, `~trigger.netdevices.NetDevice` objects are no longer
-  required to have uniform attributes.
+  required attributes, `~trigger.netdevices.NetDevice` objects:
+
+  - Are no longer required to have uniform attributes;
+  - If an attribute does it exist it may have a value of ``None``.
 
 .. _v1.5.3:
 

--- a/tests/test_netdevices.py
+++ b/tests/test_netdevices.py
@@ -87,8 +87,23 @@ class TestNetDevicesWithAcls(unittest.TestCase):
         self.assertEqual(expected, self.nd.match(vendor='juniper'))
         self.assertNotEqual(expected, self.nd.match(vendor='cisco'))
 
+    def test_match_with_null_value(self):
+        """Test the match() method when attr value is ``None``."""
+        self.device.site = None  # Zero it out!
+        expected = [self.device]
+
+        # None raw
+        self.assertEqual(expected, self.nd.match(site=None))
+
+        # "None" string
+        self.assertEqual(expected, self.nd.match(site='None'))
+
+        # Case-insensitive attr *and* value
+        self.assertEqual(expected, self.nd.match(SITE='NONE'))
+
     def tearDown(self):
         NetDevices._Singleton = None
+
 
 class TestNetDevicesWithoutAcls(unittest.TestCase):
     """
@@ -110,6 +125,7 @@ class TestNetDevicesWithoutAcls(unittest.TestCase):
 
     def tearDown(self):
         _reset_netdevices()
+
 
 class TestNetDeviceObject(unittest.TestCase):
     """

--- a/trigger/netdevices/__init__.py
+++ b/trigger/netdevices/__init__.py
@@ -930,15 +930,17 @@ class NetDevices(DictMixin):
             devices = iter(self.all())
 
             def map_attr(attr):
-                """Helper function for the lower-to-regular attribute mapping."""
+                """Helper function for lower-to-regular attribute mapping."""
                 return self._all_field_names[attr.lower()]
 
             # Use generators to keep filtering the iterator of devices.
             for attr, val in kwargs.iteritems():
                 attr = map_attr(attr)
-                val = val.lower()
+                val = str(val).lower()
                 devices = (
-                    d for d in devices if val in getattr(d, attr, '').lower()
+                    d for d in devices if (
+                        val in str(getattr(d, attr, '')).lower()
+                    )
                 )
 
             return list(devices)


### PR DESCRIPTION
- You may now also match explicitly when value is None!