### PR TITLE
Multiple bugfixes to `trigger.contrib.docommand` and `run_cmds`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,23 @@
 Changelog
 =========
 
+.. _v1.5.6:
+
+1.5.6
+=====
+
+Bug Fixes
+---------
+
+* :bug:`153` Added ``-f/--force-cli`` to ``run_cmds`` to allow CLI execution
+  on Juniper devices or any vendor platform where API support is enabled
+  by default, fixing an underlying bug where CLI output would result in a
+  crash.
+* :bug:`193` Multiple commands can now be sent to Juniper devices w/
+  ``run_cmds``.
+* Updated the Juniper CLI prompt pattern to work when a hostname isn't set
+  that would result in a ``CommandTimeout`` causing execution to fail.
+
 .. _v1.5.5:
 
 1.5.5

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 5, 5)
+__version__ = (1, 5, 6)
 
 full_version = '.'.join(str(x) for x in __version__[0:3]) + \
                ''.join(__version__[3:])

--- a/trigger/conf/global_settings.py
+++ b/trigger/conf/global_settings.py
@@ -325,7 +325,7 @@ PROMPT_PATTERNS = {
     'avocent': r'\S+[#\$]|->\s?$',
     'citrix': r'\sDone\n$',
     'f5': r'.*\(tmos\).*?#\s{1,2}\r?$',
-    'juniper': r'\S+\@\S+(?:\>|#)\s$',
+    'juniper': r'(?:\S+\@)?\S+(?:\>|#)\s$',
     'mrv': r'\r\n?.*(?:\:\d{1})?\s\>\>?$',
     'netscreen': r'(\w+?:|)[\w().-]*\(?([\w.-])?\)?\s*->\s*$',
     'paloalto': r'\r\n\S+(?:\>|#)\s?$',

--- a/trigger/contrib/docommand/__init__.py
+++ b/trigger/contrib/docommand/__init__.py
@@ -12,7 +12,7 @@ __author__ = 'Jathan McCollum, Mike Biancianello'
 __maintainer__ = 'Jathan McCollum'
 __email__ = 'jathan@gmail.com'
 __copyright__ = 'Copyright 2012-2013, AOL Inc.; 2013 Salesforce.com'
-__version__ = '3.2'
+__version__ = '3.2.1'
 
 
 # Imports
@@ -146,6 +146,10 @@ class CommandRunner(DoCommandBase):
         return lambda elt, tag: elt.findall('./' + ns + tag)
 
     def from_juniper(self, data, device, commands=None):
+        # If we've set foce_cli, use from_base() instead
+        if self.force_cli:
+            return self.from_base(data, device, commands)
+
         devname = device.nodeName
         ns = '{http://xml.juniper.net/xnm/1.1/xnm}'
         if self.verbose:
@@ -351,9 +355,11 @@ def xml_print(xml, iterations=10):
     tag = tag.replace(ns, '')
     ret.append(tag)
     children = list(xml)
+
     if len(children) < 1:
-        ptxt = tag + " : " + xml.text
+        ptxt = tag + " : " + (xml.text or '')
         return [ptxt]
+
     for child in children:
         ptxts = xml_print(child, iterations - 1)
         for t in ptxts:

--- a/trigger/contrib/docommand/core.py
+++ b/trigger/contrib/docommand/core.py
@@ -40,7 +40,7 @@ __author__ = 'Jathan McCollum, Mike Biancianello'
 __maintainer__ = 'Jathan McCollum'
 __email__ = 'jathan@gmail.com'
 __copyright__ = 'Copyright 2012-2013, AOL Inc.; 2013-2014, Salesforce.com'
-__version__ = '3.1'
+__version__ = '3.1.1'
 
 
 # Imports
@@ -57,6 +57,7 @@ PROD_ONLY = False
 DEBUG = False
 VERBOSE = False
 PUSH = False
+FORCE_CLI = False
 TIMEOUT = 30
 
 
@@ -242,12 +243,16 @@ def do_work(work=None, action_class=None):
         f = job['f']
         d = job['d']
         c = job['c']
+
         # **These next 2 lines do all the real work for this tool**
         # TODO: This will ultimately fail with a ReactorNotRestartable because
         # calling each action class separately. We need to account for this.
         # See: https://gist.github.com/jathanism/4543974
-        n = action_class(devices=d, files=f, commands=c, verbose=VERBOSE,
-                         debug=DEBUG, timeout=TIMEOUT, production_only=PROD_ONLY)
+        n = action_class(
+            devices=d, files=f, commands=c, verbose=VERBOSE, debug=DEBUG,
+            timeout=TIMEOUT, production_only=PROD_ONLY, force_cli=FORCE_CLI
+        )
+
         if PUSH:
             if VERBOSE:
                 print "running Commando"
@@ -390,6 +395,8 @@ def parse_args(argv, description=None):
                       help="""Time in seconds to wait for each command to
                       complete (default %s).""" % TIMEOUT)
     # Booleans below
+    parser.add_option('-f','--force-cli', action='store_true', default=False,
+                      help='Force CLI execution, skipping the API.')
     parser.add_option('-v','--verbose', action='store_true', default=False,
                       help='verbose output.')
     parser.add_option('-V','--debug', action='store_true', default=False,
@@ -468,8 +475,10 @@ def set_globals_from_opts(opts):
     global VERBOSE
     global PUSH
     global TIMEOUT
+    global FORCE_CLI
     DEBUG = opts.debug
     VERBOSE = opts.verbose
     PUSH = opts.push
     TIMEOUT = opts.timeout
+    FORCE_CLI = opts.force_cli
 


### PR DESCRIPTION
- Fixes #153 - Added -f/--force-cli to run_cmds to allow CLI execution
  on Juniper devices or any vendor platform where API support is enabled
  by default.
- Fixes #193 - Multiple commands can now be sent to Juniper devices w/
  run_cmds.
- Update Juniper CLI prompt pattern to work when a hostname isn't set
  that would result in a `CommandTimeout` causing execution to fail.