### PR TITLE
Bugfix in Commando "config device" plugin and a couple UX changes.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,10 +2,29 @@
 Changelog
 =========
 
+.. _v1.5.7:
+
+1.5.7 (2016-02-18)
+==================
+
+Enhancements
+------------
+
++ Added a new prompt pattern to ``settings.CONTINUE_PROMPTS``.
++ New continue prompts no longer need to be lower-cased.
++ Clarified the error text when an enable password is required but not provided
+  when connecting to a device to make it a little more clear on how to proceed.
+
+Bug Fixes
+---------
+
++ Bugfix in `~trigger.contrib.commando.plugins.config_device` causing an
+  unhandled ``NameError``.
+
 .. _v1.5.6:
 
-1.5.6
-=====
+1.5.6 (2016-02-16)
+==================
 
 Bug Fixes
 ---------
@@ -21,8 +40,8 @@ Bug Fixes
 
 .. _v1.5.5:
 
-1.5.5
-=====
+1.5.5 (2016-02-04)
+==================
 
 Bug Fixes
 ---------
@@ -33,8 +52,8 @@ Bug Fixes
 
 .. _v1.5.4:
 
-1.5.4
-=====
+1.5.4 (2016-01-29)
+==================
 
 Bug Fixes
 ---------
@@ -49,8 +68,8 @@ Bug Fixes
 
 .. _v1.5.3:
 
-1.5.3
-=====
+1.5.3 (2016-01-19)
+==================
 
 New Features
 ------------

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 5, 6)
+__version__ = (1, 5, 7)
 
 full_version = '.'.join(str(x) for x in __version__[0:3]) + \
                ''.join(__version__[3:])

--- a/trigger/conf/global_settings.py
+++ b/trigger/conf/global_settings.py
@@ -235,7 +235,8 @@ CONTINUE_PROMPTS = [
     '[y/n]:',
     '[confirm]',
     '[yes/no]: ',
-    'overwrite file [startup-config] ?[yes/press any key for no]....'
+    'overwrite file [startup-config] ?[yes/press any key for no]....',
+    'Destination filename [running-config]? ',
 ]
 
 # The file path where .gorc is expected to be found.

--- a/trigger/contrib/commando/plugins/config_device.py
+++ b/trigger/contrib/commando/plugins/config_device.py
@@ -55,7 +55,7 @@ class ConfigDevice(CommandoApplication):
         cmds = []
         files = self.files
         for fn in files:
-            copytftpcmd = "copy tftp://%s/%s running-config" % (tftp_ip, fn)
+            copytftpcmd = "copy tftp://%s/%s running-config" % (self.tftp_ip, fn)
             cmds.append(copytftpcmd)
         cmds.append('copy running-config startup-config')
         return cmds
@@ -69,7 +69,7 @@ class ConfigDevice(CommandoApplication):
             log.msg('Device Type (%s %s) not supported' % (dev.vendor, dev.make))
             return []
         for fn in files:
-            copytftpcmd = "copy tftp running-config %s %s" % (tftp_ip, fn)
+            copytftpcmd = "copy tftp running-config %s %s" % (self.tftp_ip, fn)
             if action == 'overwrite':
                 copytftpcmd += ' overwrite'
             cmds.append(copytftpcmd)
@@ -83,7 +83,7 @@ class ConfigDevice(CommandoApplication):
             log.msg('Device Type (%s %s) not supported' % (dev.vendor, dev.make))
             return cmds
         for fn in files:
-            copytftpcmd = "copy tftp://%s/%s running-config" % (tftp_ip, fn)
+            copytftpcmd = "copy tftp://%s/%s running-config" % (self.tftp_ip, fn)
             cmds.append(copytftpcmd)
         cmds.append('copy running-config startup-config')
         return cmds

--- a/trigger/twister.py
+++ b/trigger/twister.py
@@ -29,11 +29,13 @@ from trigger.conf import settings
 from trigger import tacacsrc, exceptions
 from trigger.utils import network, cli
 
+
 __author__ = 'Jathan McCollum, Eileen Tschetter, Mark Thomas, Michael Shields'
 __maintainer__ = 'Jathan McCollum'
 __email__ = 'jathan@gmail.com'
 __copyright__ = 'Copyright 2006-2013, AOL Inc.; 2013 Salesforce.com'
-__version__ = '1.5.7'
+__version__ = '1.5.8'
+
 
 # Exports
 # TODO (jathan): Setting this prevents everything from showing up in the Sphinx
@@ -90,12 +92,18 @@ def is_awaiting_confirmation(prompt):
     """
     Checks if a prompt is asking for us for confirmation and returns a Boolean.
 
+    New patterns may be added by customizing ``settings.CONTINUE_PROMPTS``.
+
+    >>> from trigger.twister import is_awaiting_confirmation
+    >>> is_awaiting_confirmation('Destination filename [running-config]? ')
+    True
+
     :param prompt:
         The prompt string to check
     """
     prompt = prompt.lower()
     matchlist = settings.CONTINUE_PROMPTS
-    return any(prompt.endswith(match) for match in matchlist)
+    return any(prompt.endswith(match.lower()) for match in matchlist)
 
 
 def requires_enable(proto_obj, data):
@@ -152,7 +160,9 @@ def send_enable(proto_obj, disconnect_on_fail=True):
         log.msg('[%s] Enable password not found, not enabling.' %
                 proto_obj.device)
         proto_obj.factory.err = exceptions.EnablePasswordFailure(
-            'Enable password not set.')
+            'Enable password not set. See documentation on '
+            'settings.TRIGGER_ENABLEPW for help.'
+        )
         if disconnect_on_fail:
             proto_obj.loseConnection()
 


### PR DESCRIPTION
- Added a new prompt pattern to `settings.CONTINUE_PROMPTS`.
- New continue prompts no longer need to be lower-cased.
- Clarified the error text when an enable password is required but not
  provided when connecting to a device to make it a little more clear on
  how to proceed.
- Bugfix in `~trigger.contrib.commando.plugins.config_device` causing an
  unhandled `NameError`.