### PR TITLE
Bugfix for Cisco NX-OS devices where async execution would sometimes …

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,10 @@ Bug Fixes
 
 + :bug:`259` - Bugfix in `~trigger.utils.core.pretty_time()` where ``pytz`` was
   being referenced but not imported.
++ Extended prompt detection for IOS-like devices to include backspace
+  characters (``\b`` or ``\x08``) which is sometimes seen on Cisco NX-OS
+  devices, and would cause asynchronous execution to sometimes hang and result
+  in a `~trigger.exceptions.CommandTimeout` error.
 
 .. _v1.5.8:
 

--- a/tests/test_twister.py
+++ b/tests/test_twister.py
@@ -1,0 +1,36 @@
+
+
+import re
+
+import pytest
+
+from trigger.conf import settings
+
+
+def test_ioslike_prompt_pattern_enabled():
+    """Test enabled that IOS-like prompt patterns match correctly."""
+    pat = settings.IOSLIKE_PROMPT_PAT
+
+    prompt_tests = [
+        'foo-bar1#',
+        'foo-bar1# ',
+        'foo-bar1(config)# ',
+        '\rfoo-bar01(config)# \x08 ',  # "Bonus" backspace in there
+    ]
+
+    for prompt in prompt_tests:
+        assert re.search(pat, prompt) is not None
+
+
+def test_ioslike_prompt_pattern_nonenabled():
+    """Test non-enabled that IOS-like prompt patterns match correctly."""
+    pat = settings.IOSLIKE_ENABLE_PAT
+
+    prompt_tests = [
+        'foo-bar1>',
+        'foo-bar1> ',
+        '\rfoo-bar01)> \x08 ',  # "Bonus" backspace in there
+    ]
+
+    for prompt in prompt_tests:
+        assert re.search(pat, prompt) is not None

--- a/trigger/conf/global_settings.py
+++ b/trigger/conf/global_settings.py
@@ -344,8 +344,8 @@ PROMPT_PATTERNS = {
 
 # When a pattern is not explicitly defined for a vendor, this is what we'll try
 # next (since most vendors are in fact IOS-like).
-IOSLIKE_PROMPT_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?#[\s\b]+?$'
-IOSLIKE_ENABLE_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?>[\s\b]+?$'
+IOSLIKE_PROMPT_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?#[\s\b]*$'
+IOSLIKE_ENABLE_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?>[\s\b]*$'
 
 # Generic prompt to match most vendors. It assumes that you'll be greeted with
 # a "#" prompt.


### PR DESCRIPTION

+ Extended prompt detection for IOS-like devices to include backspace
  characters ('\b' or '\x08') which is sometimes seen on Cisco NX-OS
  devices, and would cause asynchronous execution to sometimes hang and result
  in a `~trigger.exceptions.CommandTimeout` error.