### PR TITLE
Usability bug fixes to load_acl and its related settings.

### DIFF
--- a/bin/load_acl
+++ b/bin/load_acl
@@ -459,11 +459,23 @@ def group(dev):
     :param dev:
         The `~trigger.netdevices.NetDevice` object to try to group
     """
+    # TODO(jathan): Make this pattern configurable globally.
     trimmer = re.compile('[0-9]*[a-z]+')   # allow for e.g. "36bit1"
-    x = trimmer.match(dev.nodeName).group()
-    if len(x) >= 4 and x[-1] not in ('i', 'e'):
-        x = x[:-1] + 'X'
-    return (dev.site, x)
+
+    # Try to match on nodeName, and if we don't (such as if it's an IP
+    # address), just skip grouping.
+    match = trimmer.match(dev.nodeName)
+    if not match or not dev.site:
+        return dev.nodeName
+
+    group_key = match.group()
+
+    # FIXME(jathan): This is some hard-coded AOL-specific legacy stuff that
+    # will probably work for most environments, but it's awfully presumptuous.
+    if len(group_key) >= 4 and group_key[-1] not in ('i', 'e'):
+        group_key = group_key[:-1] + 'X'
+
+    return (dev.site, group_key)
 
 def select_next_device(work, active):
     """
@@ -554,7 +566,7 @@ def activate(work, active, failures, jobs, redraw):
         def check_failure(result, dev):
             (acl_contents, tftp_paths, fails) = result
 
-            if fails is not None:
+            if fails:
                 log.msg("STAGING FAILED:", fails)
                 raise exceptions.ACLStagingFailed(fails)
 

--- a/conf/trigger_settings.py
+++ b/conf/trigger_settings.py
@@ -472,53 +472,44 @@ BULK_MAX_HITS_DEFAULT = 1
 #===============================
 # OnCall Engineer Display
 #===============================
-# This variable should be a function that returns data for your on-call engineer, or
+# This should be a callable that returns data for your on-call engineer, or
 # failing that None.  The function should return a dictionary that looks like
 # this:
 #
 # {'username': 'joegineer',
 #  'name': 'Joe Engineer',
 #  'email': 'joe.engineer@example.notreal'}
-def get_current_oncall():
-    """fetch current on-call info"""
-    # from somewhere import get_primary_oncall()
+#
+# If you want to disable it, just have it return a non-False value.
+# If you want to use it and have it block, have it return a False value (such
+# as None)
+#
+# This example is just providing a string that indicates that on-call lookup is
+# disabled.
+#
+# Default: returns 'disabled'
+def _get_current_oncall_stub(*args, **kwargs):
+    return 'disabled'
 
-    try:
-        ret = get_primary_oncall()
-    except:
-        return None
-
-    return ret
-
-# If you don't want to return this information, have it return None.
-GET_CURRENT_ONCALL = lambda x=None: x
-#GET_CURRENT_ONCALL = get_current_oncall
+GET_CURRENT_ONCALL = _get_current_oncall_stub
 
 #===============================
 # CM Ticket Creation
 #===============================
-# This should be a function that creates a CM ticket and returns the ticket
-# number, or None.
-# TODO (jathan): Improve this interface so that it is more intuitive.
-def create_cm_ticket(acls, oncall, service='load_acl'):
-    """Create a CM ticket and return the ticket number or None"""
-    # from somewhere import create_cm_ticket
+# This should be a callable that creates a CM ticket and returns the ticket
+# number.
+#
+# If you want to disable it, just have it return a non-False value.
+# If you want to use it and have it block, have it return a False value (such
+# as None)
+#
+# This example is just providing a string that indicates that CM ticket
+# creation is disabled.
+#
+# Default: returns ' N/A (CM ticket creation is disabled)'
+def _create_cm_ticket_stub(*args, **kwargs):
+    return ' N/A (CM ticket creation is disabled)'
 
-    devlist = ''
-    for dev, aclset in acls.items():
-        a = sorted(aclset)
-        devlist += "%-32s %s\n" % (dev, ' '.join(a))
-
-    oncall['devlist'] = devlist
-    oncall['service'] = service
-
-    return create_ticket(**oncall)
-
-def _create_cm_ticket_stub(**args):
-    return None
-
-# If you don't want to use this feature, just have the function return None.
-#CREATE_CM_TICKET = lambda a=None o, s: None
 CREATE_CM_TICKET = _create_cm_ticket_stub
 
 #===============================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,8 @@ Changelog
 
 .. _v1.5.9:
 
-1.5.9 (??)
-==========
+1.5.9 (2016-04-01)
+==================
 
 Bug Fixes
 ---------
@@ -18,6 +18,21 @@ Bug Fixes
   characters (``\b`` or ``\x08``) which is sometimes seen on Cisco NX-OS
   devices, and would cause asynchronous execution to sometimes hang and result
   in a `~trigger.exceptions.CommandTimeout` error.
+* Improved the internal grouping logic for ``load_acl`` to be more
+  permissive and if grouping fails it will just not group devices.
+* Fixed a bug that would prevent ACL staging from working when using
+  default global settings.
+* Fixed bugs in the default global callables for ``get_current_oncall()``
+  and ``create_tm_ticket()`` that would prevent ``lod_acl`` from working.
+  They now default to a disabled state that does not require
+  customization just to utilize core load_acl functionality.
+* Updated the sample ``settings.py`` (``conf/trigger_settings.py``) to
+  utilize the updated default callables.
+* Fixed a bug in default global callable for ``get_tftp_source()`` to
+  properly perform lookup of :setting:`VIPS`
+* Fixed a bug in default global callable for ``stage_acls()`` to
+  properly perform lookup of :setting:`FIREWALL_DIR` and
+  :setting:`TFTPROOT_DIR`.
 
 .. _v1.5.8:
 


### PR DESCRIPTION
- Improved the internal grouping logic for `load_acl` to be more
  permissive and if grouping fails it will just not group devices.
- Fixed a bug that would prevent ACL staging from working when using
  default global settings.
- Fixed bugs in the default global callables for `get_current_oncall()`
  and `create_tm_ticket()` that would prevent `lod_acl` from working.
  They now default to a disabled state that does not require
  customization just to utilize core load_acl functionality.
- Updated the sample `settings.py` (`conf/trigger_settings.py`) to
  utilize the updated default callables.
- Fixed a bug in default global callable for `get_tftp_source()` to
  properly perform lookup of `settings.VIPS`
- Fixed a bug in default global callable for `stage_acls()` to
  properly perform lookup of `settings.FIREWALL_DIR` and
  `settings.TFTPROOT_DIR`.