### PR TITLE
Adjust IOS-like prompt pattern to handle `\s\r` *inside* of prompts.

### DIFF
--- a/conf/trigger_settings.py
+++ b/conf/trigger_settings.py
@@ -329,8 +329,8 @@ PROMPT_PATTERNS = {
 
 # When a pattern is not explicitly defined for a vendor, this is what we'll try
 # next (since most vendors are in fact IOS-like)
-IOSLIKE_PROMPT_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?#\s?$'
-IOSLIKE_ENABLE_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?>\s?$'
+IOSLIKE_PROMPT_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?[\r\s]*#[\s\b]*$'
+IOSLIKE_ENABLE_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?[\r\s]*>[\s\b]*$'
 
 # Generic prompt to match most vendors. It assumes that you'll be greeted with
 # a "#" prompt.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,19 @@
 Changelog
 =========
 
+.. _v1.5.10:
+
+1.5.10 (??)
+===========
+
+Bug Fixes
+---------
+
++ Extended prompt detection for IOS-like devices to include interstitial space
+  (``\s``) or carriage return (``\r``) characters which is sometimes seen on
+  Arista EOS devices, and would cause asynchronous execution to sometimes hang
+  and result in a `~trigger.exceptions.CommandTimeout` error.
+
 .. _v1.5.9:
 
 1.5.9 (2016-04-01)

--- a/tests/test_twister.py
+++ b/tests/test_twister.py
@@ -16,6 +16,7 @@ def test_ioslike_prompt_pattern_enabled():
         'foo-bar1# ',
         'foo-bar1(config)# ',
         '\rfoo-bar01(config)# \x08 ',  # "Bonus" backspace in there
+        'foo-bar01(config) \r#',  # "Bonus" '\s\r' in there
     ]
 
     for prompt in prompt_tests:
@@ -30,6 +31,7 @@ def test_ioslike_prompt_pattern_nonenabled():
         'foo-bar1>',
         'foo-bar1> ',
         '\rfoo-bar01)> \x08 ',  # "Bonus" backspace in there
+        'foo-bar01) \r>',  # "Bonus" '\s\r' in there
     ]
 
     for prompt in prompt_tests:

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 5, 9)
+__version__ = (1, 5, 10)
 
 full_version = '.'.join(str(x) for x in __version__[0:3]) + \
                ''.join(__version__[3:])

--- a/trigger/conf/global_settings.py
+++ b/trigger/conf/global_settings.py
@@ -344,8 +344,8 @@ PROMPT_PATTERNS = {
 
 # When a pattern is not explicitly defined for a vendor, this is what we'll try
 # next (since most vendors are in fact IOS-like).
-IOSLIKE_PROMPT_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?#[\s\b]*$'
-IOSLIKE_ENABLE_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?>[\s\b]*$'
+IOSLIKE_PROMPT_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?[\r\s]*#[\s\b]*$'
+IOSLIKE_ENABLE_PAT = r'\S+(\(config(-[a-z:1-9]+)?\))?[\r\s]*>[\s\b]*$'
 
 # Generic prompt to match most vendors. It assumes that you'll be greeted with
 # a "#" prompt.


### PR DESCRIPTION
- This apparently happens sometimes with Arista switches.
- Unit tests updated.