### PR TITLE
Don't complete when using `--no-db`

### DIFF
--- a/bin/load_acl
+++ b/bin/load_acl
@@ -548,7 +548,8 @@ def activate(work, active, failures, jobs, redraw):
                 pass
 
         def complete(results, dev, acls):
-            clear_load_queue(dev, acls)
+            if queue:
+                clear_load_queue(dev, acls)
 
         def eb(reason, dev):
             log.msg("GOT ERRBACK", reason)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,11 @@ Bug Fixes
   (``\s``) or carriage return (``\r``) characters which is sometimes seen on
   Arista EOS devices, and would cause asynchronous execution to sometimes hang
   and result in a `~trigger.exceptions.CommandTimeout` error.
++ :bug:`269` - Bugfix in ``bin/load_acl`` that prevents ``queue.complete()``
+  from being called when using the ``--no-db`` flag.  Previously, an
+  ``AttributeError`` attribute error was raised due to attempting to call
+  ``complete`` on ``queue``, which is set to ``None`` when passing
+  ``--no-db``.
 
 .. _v1.5.9:
 


### PR DESCRIPTION
Specifying the `--no-db` switch causes `queue` to be set to `None`,
which is later send the `complete` message.  This makes it so that we
only call` queue.complete` if we didn't specify `--no-db`.

Fixes trigger/trigger#269.