### PR TITLE
Cleanly close /dev/null fd in `utils.network.ping`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ Bug Fixes
   ``AttributeError`` attribute error was raised due to attempting to call
   ``complete`` on ``queue``, which is set to ``None`` when passing
   ``--no-db``.
++ :bug:`271` - Bugfix in `~trigger.utils.network.ping()` where a file
+  descriptor wasn't closed cleanly.
 
 .. _v1.5.9:
 

--- a/trigger/utils/network.py
+++ b/trigger/utils/network.py
@@ -43,12 +43,13 @@ def ping(host, count=1, timeout=5):
     """
 
     ping_command = "ping -q -c%d -W%d %s" % (count, timeout, host)
-    DEVNULL = open(os.devnull, 'w')
-    status = subprocess.call(
-        shlex.split(ping_command),
-        stdout=DEVNULL,
-        stderr=DEVNULL,
-        close_fds=True)
+    status = None
+    with open(os.devnull, 'w') as devnull_fd:
+        status = subprocess.call(
+            shlex.split(ping_command),
+            stdout=devnull_fd,
+            stderr=devnull_fd,
+            close_fds=True)
 
     # Linux RC: 0 = success, 256 = failure, 512 = unknown host
     # Darwin RC: 0 = success, 512 = failure, 17408 = unknown host


### PR DESCRIPTION
Cleanly closes a file descriptor in `trigger.utils.network.ping`.
Although exiting a function would forcefully close the fd, it's better
to close it cleanly and explicitly.

Fixes trigger/trigger#271