### PR TITLE
Print the device name with the device's table

### DIFF
--- a/bin/gnng
+++ b/bin/gnng
@@ -297,9 +297,6 @@ def build_output(main_data, opts, labels=None):
 
     for dev, data in main_data.iteritems():
         rows = []
-        if not opts.csv and not opts.dotty:
-            print "DEVICE: %s" % dev
-
         interfaces = sorted(data)
         for interface in interfaces:
             iface = data[interface]
@@ -370,6 +367,7 @@ def handle_output(all_rows, opts):
         elif opts.sqldb:
             write_sqldb(opts.sqldb, dev, rows)
         else:
+            print 'DEVICE: {}'.format(dev)
             print_table(rows)
 
 def print_table(rows, labels=None, has_header=True, separate_rows=False,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ Bug Fixes
   ``--no-db``.
 + :bug:`271` - Bugfix in `~trigger.utils.network.ping()` where a file
   descriptor wasn't closed cleanly.
++ :bug:`167` - Bugfix in ``bin/gnng`` that printed device names before any
+  tables, resulting in potentially confusing results.  Devices names are now
+  printed with the corresponding table.
 
 .. _v1.5.9:
 


### PR DESCRIPTION
This stops printing the device name at the top of all output and instead
prints it just before the actual table of data.

Fixes trigger/trigger#167