### PR TITLE
Allow `gnng --filter-on-type='STRING'` to execute

### DIFF
--- a/bin/gnng
+++ b/bin/gnng
@@ -77,7 +77,7 @@ default. Works on Cisco, Foundry, Juniper, and NetScreen devices.''')
 
     opts, args = parser.parse_args(argv)
 
-    if len(args) == 1 and not opts.all:
+    if len(args) == 1 and not opts.all and not opts.filter_on_type:
         parser.print_help()
         sys.exit(1)
 
@@ -436,7 +436,7 @@ def output_dotty(subnet_table, display=True):
 
 def main():
 
-    if opts.all:
+    if opts.all or opts.filter_on_type:
         routers = fetch_router_list(None)
     else:
         routers = fetch_router_list(args[1:])

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ Bug Fixes
 + :bug:`167` - Bugfix in ``bin/gnng`` that printed device names before any
   tables, resulting in potentially confusing results.  Devices names are now
   printed with the corresponding table.
++ :bug:`257` - Bugfix in ``bin/gnng`` that allows the ``--filter-on-type``
+  to function as expected.
 
 .. _v1.5.9:
 


### PR DESCRIPTION
Add conditionals to allow `gnng` to execute properly when passing the
`--filter-on-type` option.

Fixes issue #2 in trigger/trigger#257.