### PR TITLE
Update documentation for `gnng` `--noprod` flag.

### DIFF
--- a/bin/gnng
+++ b/bin/gnng
@@ -65,7 +65,8 @@ default. Works on Cisco, Foundry, Juniper, and NetScreen devices.''')
     parser.add_option('-j', '--jobs', type='int', default=MAX_CONNS,
                       help='maximum simultaneous connections to maintain.')
     parser.add_option('-N', '--nonprod', action='store_false', default=True,
-                      help='Look for production and non-production devices.')
+                      help='Include non-production devices from the query or '
+                      '[routers].  Requires a legitimate query.')
     parser.add_option('-s', '--sqldb', type='str',
                       help='output to SQLite DB')
     parser.add_option('', '--dotty', action='store_true',

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ Bug Fixes
   printed with the corresponding table.
 + :bug:`257` - Bugfix in ``bin/gnng`` that allows the ``--filter-on-type``
   to function as expected.
++ Update documentation of ``gnng``'s ``-N``/``--nonprod`` flag.
 
 .. _v1.5.9:
 


### PR DESCRIPTION
Update help string for `-N`/`--noprod` flag for `gnng` to mention that a
legitimate query is required in addition to the `-N`/`--noprod` flag.

Fixes third issue of trigger/trigger#257.