### PR TITLE
Bugfix in `bin/gnng --all` that was too specific with vendor filters.

### DIFF
--- a/bin/gnng
+++ b/bin/gnng
@@ -102,13 +102,9 @@ def fetch_router_list(args):
         for entry in nd.itervalues():
             if entry.owningTeam in blocked_groups:
                 continue
-            if entry.vendor in ('cisco', 'foundry', 'juniper'):
-                if 'oob' in entry.shortName:
-                    continue
-
-                if not pass_filters(entry):
-                    continue
-                ret.append(entry)
+            if not pass_filters(entry):
+                continue
+            ret.append(entry)
 
     return sorted(ret, reverse=True)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,10 @@ Bug Fixes
 + Update documentation of ``gnng``'s ``-N``/``--nonprod`` flag.
 + :bug:`89` - Bugfix in ``bin/gnng`` that allows ``gnng`` to fail gracefully
   when a device isn't found.
++ Bugfix in ``bin/gnng --all`` that was causing many device vendors to be
+  skipped entirely because the filter was too specific. This vendor filter has
+  been removed and will now fallback to `~trigger.cmds.NetACLInfo()` internal
+  knowledge of supported platforms.
 
 .. _v1.5.9:
 


### PR DESCRIPTION
- This was causing vendors like Arista (for example) to be skipped
  entirely under `--all`