### PR TITLE
Gracefully skip devices that can't be found

### DIFF
--- a/bin/gnng
+++ b/bin/gnng
@@ -28,7 +28,7 @@ from sqlite3 import dbapi2 as sqlite
 import sys
 from twisted.python import log
 from trigger.cmds import NetACLInfo
-from trigger.netdevices import NetDevices
+from trigger.netdevices import device_match, NetDevices
 
 # Put this here until the default changes to not load ACLs from redis.
 from trigger.conf import settings
@@ -92,9 +92,11 @@ def fetch_router_list(args):
     blocked_groups = []
     if args:
         for arg in args:
-            if not pass_filters(nd.find(arg)):
+            # Try to find the device, but fail gracefully if it can't be found
+            device = device_match(arg)
+            if not pass_filters(device) or device is None:
                 continue
-            ret.append(nd.find(arg))
+            ret.append(device)
 
     else:
         for entry in nd.itervalues():

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,8 @@ Bug Fixes
 + :bug:`257` - Bugfix in ``bin/gnng`` that allows the ``--filter-on-type``
   to function as expected.
 + Update documentation of ``gnng``'s ``-N``/``--nonprod`` flag.
++ :bug:`89` - Bugfix in ``bin/gnng`` that allows ``gnng`` to fail gracefully
+  when a device isn't found.
 
 .. _v1.5.9:
 


### PR DESCRIPTION
Catch the `KeyError` exception from `NetDevices.find()` so that we don't
bubble it up to the end user.  Allows us to continue with any other
valid devices while pointing out that the invalid ones couldn't be
found.

Fixes trigger/trigger#89.