### PR TITLE
check_syntax: Check if supplied file is a normal file

### DIFF
--- a/bin/check_syntax
+++ b/bin/check_syntax
@@ -38,6 +38,12 @@ def main():
     opts, args = parse_args(sys.argv)
 
     for file in args[1:]:
+        if not os.path.exists(file):
+            print 'Moving on.  File does not exist: {}'.format(file)
+            continue
+        if not os.path.isfile(file):
+            print 'Moving on.  Not a normal file: {}'.format(file)
+            continue
         fd = open(file, 'r')
         file_contents = fd.read()
 

--- a/bin/check_syntax
+++ b/bin/check_syntax
@@ -44,8 +44,8 @@ def main():
         if not os.path.isfile(file):
             print 'Moving on.  Not a normal file: {}'.format(file)
             continue
-        fd = open(file, 'r')
-        file_contents = fd.read()
+        # Calling `read()` on the fd immediately closes it
+        file_contents = open(file, 'r').read()
 
         try:
             acl_parse(file_contents)


### PR DESCRIPTION
`check_syntax`: Skips the argument if it's not a regular file (i.e.,
it's a directory).  Also determine if argument is a valid path.

Fixes trigger/trigger#165.