### PR TITLE
check_access: Print suggested edit if check fails

### DIFF
--- a/bin/check_access
+++ b/bin/check_access
@@ -82,4 +82,6 @@ if permitted and not opts.quiet:
 if permitted:
     sys.exit(0)
 else:
+    print 'Not permitted.  Consider the following edit:'
+    print '\n'.join(new_term.output(acl.format))
     sys.exit(1)


### PR DESCRIPTION
This now prints a notice that the source/destination/port/protocol tuple
that was checked is not explicitly permitted.  It also prints out a
suggested edit that would allow it.

Fixes trigger/trigger#283.