### PR TITLE
check_access: updates docs for suggested edits

### DIFF
--- a/bin/check_access
+++ b/bin/check_access
@@ -20,7 +20,9 @@ from trigger.acl.tools import check_access, create_trigger_term
 
 optp = optparse.OptionParser(description='''\
 Determine whether access is permitted by a given ACL.  Exits 0 if permitted,
-1 if edits are needed. Lists the terms that apply and what edits are needed.''',
+1 if edits are needed. Lists the terms that apply and what edits are needed.
+Note that in order for the suggested edits feature to work, your policy must
+end with an explicit deny.''',
     usage='%prog [opts] file source dest [protocol [port]]')
 optp.add_option('-q', '--quiet', action='store_true', help='suppress output')
 (opts, args) = optp.parse_args()

--- a/docs/usage/scripts/check_access.rst
+++ b/docs/usage/scripts/check_access.rst
@@ -47,6 +47,10 @@ any source to the destination ``10.20.30.40`` in the policy ``acl.abc123``::
 It adds a comment that says ``"check_access: ADD THIS TERM"``, followed by the
 policy one would need to add, and where (above the explicit deny).
 
+.. note::
+    In order for the suggested edits feature to work, the policy must end
+    with an explicit deny.
+
 Now if it were permitted, say if we chose ``10.17.18.19`` as the source, it
 would tell you something different::
 


### PR DESCRIPTION
Updates documentation for `check_access` to also mention that an
explicit deny must exist in a policy for the suggested edits feature to
work.

Fixes trigger/trigger#283.