### PR TITLE
Enhancements/bug fixes to implement support for Cumulus Linux

### DIFF
--- a/configs/trigger_settings.py
+++ b/configs/trigger_settings.py
@@ -51,26 +51,31 @@ INTERNAL_NETWORKS = [
     IPy.IP("192.168.0.0/16"),
 ]
 
-# The tuple of supported vendors derived from the values of VENDOR_MAP
-SUPPORTED_VENDORS = (
-    'a10',
-    'arista',
-    'aruba',
-    'avocent',
-    'brocade',
-    'cisco',
-    'citrix',
-    'dell',
-    'f5',
-    'force10',
-    'foundry',
-    'juniper',
-    'mrv',
-    'netscreen',
-    'paloalto',
-    'pica8',
-)
-VALID_VENDORS = SUPPORTED_VENDORS # For backwards compatibility
+# A dictionary keyed by manufacturer name containing a list of the device types
+# for each that is officially supported by Trigger.
+SUPPORTED_PLATFORMS = {
+    'a10': ['SWITCH'],
+    'arista': ['SWITCH'],                         # Your "Cloud" network vendor
+    'aruba': ['SWITCH'],                          # Aruba Wi-Fi controllers
+    'avocent': ['CONSOLE'],
+    'brocade': ['ROUTER', 'SWITCH'],
+    'cisco': ['ROUTER', 'SWITCH', 'FIREWALL'],
+    'citrix': ['SWITCH'],                         # Assumed to be NetScalers
+    'cumulus': ['SWITCH'],  # Any white-label hardware running Cumulus Linux
+    'dell': ['SWITCH'],
+    'f5': ['LOAD_BALANCER', 'SWITCH'],
+    'force10': ['ROUTER', 'SWITCH'],
+    'foundry': ['ROUTER', 'SWITCH'],
+    'juniper': ['FIREWALL', 'ROUTER', 'SWITCH'],  # Any devices running Junos
+    'mrv': ['CONSOLE', 'SWITCH'],
+    'netscreen': ['FIREWALL'],                    # Pre-Juniper NetScreens
+    'paloalto': ['FIREWALL'],
+    'pica8': ['ROUTER', 'SWITCH'],
+}
+
+# List of supported vendor names derived from SUPPORTED_PLATFORMS
+SUPPORTED_VENDORS = list(SUPPORTED_PLATFORMS)
+VALID_VENDORS = SUPPORTED_VENDORS  # For backwards compatibility
 
 # A mapping of manufacturer attribute values to canonical vendor name used by
 # Trigger. These single-word, lowercased canonical names are used throughout
@@ -84,8 +89,10 @@ VENDOR_MAP = {
     'ARUBA NETWORKS': 'aruba',
     'AVOCENT': 'avocent',
     'BROCADE': 'brocade',
+    'CELESTICA': 'cumulus',
     'CISCO SYSTEMS': 'cisco',
     'CITRIX': 'citrix',
+    'CUMULUS': 'cumulus',
     'DELL': 'dell',
     'F5 NETWORKS': 'f5',
     'FORCE10': 'force10',
@@ -93,29 +100,7 @@ VENDOR_MAP = {
     'JUNIPER': 'juniper',
     'MRV': 'mrv',
     'NETSCREEN TECHNOLOGIES': 'netscreen',
-    'PALO ALTO NETWORKS': 'paloalto',
     'PICA8': 'pica8',
-}
-
-# A dictionary keyed by manufacturer name containing a list of the device types
-# for each that is officially supported by Trigger.
-SUPPORTED_PLATFORMS = {
-    'a10': ['SWITCH'],
-    'arista': ['SWITCH'],                         # Your "Cloud" network vendor
-    'aruba': ['SWITCH'],                          # Wireless Controllers
-    'avocent': ['CONSOLE'],
-    'brocade': ['ROUTER', 'SWITCH'],
-    'cisco': ['FIREWALL', 'ROUTER', 'SWITCH'],
-    'citrix': ['SWITCH'],                         # Assumed to be NetScalers
-    'dell': ['SWITCH'],
-    'f5': ['LOAD_BALANCER', 'SWITCH'],
-    'force10': ['ROUTER', 'SWITCH'],
-    'foundry': ['ROUTER', 'SWITCH'],
-    'juniper': ['FIREWALL', 'ROUTER', 'SWITCH'],  # Any devices running Junos
-    'mrv': ['CONSOLE', 'SWITCH'],
-    'netscreen': ['FIREWALL'],                    # Pre-Juniper NetScreens
-    'paloalto': ['FIREWALL'],
-    'pica8': ['ROUTER', 'SWITCH'],
 }
 
 # The tuple of support device types
@@ -139,6 +124,7 @@ DEFAULT_TYPES = {
     'brocade': 'SWITCH',
     'citrix': 'SWITCH',
     'cisco': 'ROUTER',
+    'cumulus': 'SWITCH',
     'dell': 'SWITCH',
     'f5': 'LOAD_BALANCER',
     'force10': 'ROUTER',
@@ -204,10 +190,41 @@ IOSLIKE_VENDORS = (
     'aruba',
     'brocade',
     'cisco',
+    'cumulus',
     'dell',
     'force10',
     'foundry',
 )
+
+
+# Commands executed on devices by default.
+STARTUP_COMMANDS_DEFAULT = ['terminal length 0']
+
+# Startup commands are executed upon login to setup the terminal session for
+# automated execution. Typically these are just to disable pagination or other
+# settings related to capturing output asynchronously. Each vendor is mapped by
+# name. Vendor platforms with differing startup commands based on their device
+# type are now mapped with an underscore separation (e.g. 'Cisco ASA' becomes
+# 'cisco_asa'). The platform-specific lookups are still done in code for now.
+STARTUP_COMMANDS_MAP = {
+    'a10': STARTUP_COMMANDS_DEFAULT,
+    'arista': STARTUP_COMMANDS_DEFAULT,
+    'aruba': ['no paging'], # v6.2.x this is not necessary
+    'brocade': ['skip-page-display'],
+    'brocade_vdx': STARTUP_COMMANDS_DEFAULT,
+    'cisco': STARTUP_COMMANDS_DEFAULT,
+    'cisco_asa': ['terminal pager 0'],
+    'citrix': ['set cli mode page off'],
+    'cumulus': ['sudo vtysh'] + STARTUP_COMMANDS_DEFAULT,
+    'dell': ['terminal datadump'],
+    'f5': ['modify cli preference pager disabled'],
+    'force10': STARTUP_COMMANDS_DEFAULT,
+    'foundry': ['skip-page-display'],
+    'juniper': ['set cli screen-length 0'],
+    'mrv': ['no pause'],
+    'netscreen': ['set console page 0'],
+    'paloalto': ['set cli scripting-mode on', 'set cli pager off'],
+}
 
 # Prompts sent by devices that indicate the device is awaiting user
 # confirmation when interacting with the device. If a continue prompt is
@@ -327,8 +344,12 @@ PROMPT_PATTERNS = {
     #'aruba': r'\S+(?: \(\S+\))?\s?#\s$', # ArubaOS 6.2
     'avocent': r'\S+[#\$]|->\s?$',
     'citrix': r'\sDone\n$',
+    # 'cumulus': r'\S+(?:\$|#)\s?$',  # Used to run 'sudo vtysh' only.
+    # This pattern is a regex "or" combination of the Cumulus bash login prompt
+    # and IOSLIKE_PROMPT_PAT
+    'cumulus': r'(?:\S+(\(config(-[a-z:1-9]+)?\))?[\r\s]*#[\s\b]*$)|(?:\S+(?:\$|#)\s?$)',
     'f5': r'.*\(tmos\).*?#\s{1,2}\r?$',
-    'juniper': r'\S+\@\S+(?:\>|#)\s$',
+    'juniper': r'(?:\S+\@)?\S+(?:\>|#)\s$',
     'mrv': r'\r\n?.*(?:\:\d{1})?\s\>\>?$',
     'netscreen': r'(\w+?:|)[\w().-]*\(?([\w.-])?\)?\s*->\s*$',
     'paloalto': r'\r\n\S+(?:\>|#)\s?$',

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 6, 'pre')
+__version__ = (1, 6, 'rc2')
 
 full_version = '.'.join(str(x) for x in __version__[0:3]) + \
                ''.join(__version__[3:])

--- a/trigger/twister.py
+++ b/trigger/twister.py
@@ -1345,6 +1345,7 @@ class TriggerSSHChannelBase(channel.SSHChannel, TimeoutMixin, object):
                 log.msg('[%s] Successfully initialized for command execution' %
                         self.device)
                 self.initialized = True
+                self.enabled = True  # Disable further enable checks.
 
         if self.incremental:
             self.incremental(self.results)


### PR DESCRIPTION
- Implemented initial support for devices running Cumulus Linux with a
  few caveats:
  1. It is expected that the user logs into a bash shell
  2. `sudo vtysh` is immediately executed
  3. The driver is categorized as IOS-like to facilitate ease of
     interaction with the `vtysh` session.
- Added a device identity check for Cumulus:
  `trigger.netdevices.NetDevice.is_cumulus()`
- Fixed a bug in which `trigger.cmds.Commando` instances would never
  stop running because of changes made to support persistent channels
  using crochet.
- Added a `stop_reactor` argument that defaults to `True` to
  `trigger.cmds.Commando` so that it will stop the reactory loop by
  default. Setting `stop_reactor=False` will make `Commando` instances
  now behave like `ReactorlessCommando` instances.
- Fixed a bug in which enable prompt would sometimes be erroneously
  detected on Cumulus devices in `vtysh` output because of lines ending
  in ">\n".
- Moved startup command definitions into a new setting called
  `settings.STARTUP_COMMANDS_MAP`. This is not quite complete but is an
  interim step to moving hard-coded device identification logic out of
  `trigger.netdevices` and into drivers.
  - Vendor platforms with differing startup commands based on their
    device type are now mapped with an underscore separation (e.g.
    'Cisco ASA' becomes 'cisco_asa').
- Added "Celestica" as a known white-label vendor for the purpose of
  mapping to the vendor "cumulus" for driver selection.
- The setting SUPPORTED_VENDORS is now derived from SUPPORTED_PLATFORMS
  as a step to unify the two settings. This is because platforms (dict)
  has the same keys as vendors (list).