### PR TITLE
Bugfix in trigger.twister2 causing default credentials to not be used.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from trigger import release as __version__
 requires = [
     'IPy>=0.73',
     'cryptography==1.4',
-    'Twisted>=15.4.0,<16.3.0',
+    'Twisted>=15.4.0,<17.0.0',
     'crochet==1.5.0',
     'mock==2.0.0',
     'pyasn1', # Twisted conch needs this, but doesn't say so

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 6, 'rc2')
+__version__ = (1, 6, 'rc3')
 
 full_version = '.'.join(str(x) for x in __version__[0:3]) + \
                ''.join(__version__[3:])

--- a/trigger/netdevices/__init__.py
+++ b/trigger/netdevices/__init__.py
@@ -447,10 +447,6 @@ class NetDevice(object):
         self.implicit_acls = acls_dict['implicit']
         self.acls = acls_dict['all']
 
-    def _is_connected(self):
-        """TODO: Validate really connected to endpoint"""
-        self._connected = True
-
     def __str__(self):
         return self.nodeName
 
@@ -517,7 +513,7 @@ class NetDevice(object):
             inject_net_device_into_protocol
         )
 
-        self._connected = self._is_connected()
+        self._connected = True
         return self._connected
 
     def close(self):

--- a/trigger/twister2.py
+++ b/trigger/twister2.py
@@ -36,13 +36,12 @@ from twisted.python import log
 from trigger.conf import settings
 from trigger import tacacsrc, exceptions
 from trigger.twister import is_awaiting_confirmation, has_ioslike_error, TriggerSSHUserAuth
-from trigger import tacacsrc
 from twisted.internet import reactor
 
 
 @run_in_reactor
 def generate_endpoint(device):
-    creds = tacacsrc.get_device_password(device.nodeName)
+    creds = tacacsrc.validate_credentials()
     return TriggerSSHShellClientEndpointBase.newConnection(
         reactor, creds.username, device, password=creds.password
     )


### PR DESCRIPTION
- Bugfix in NetDevice.connected never returning the correct connection
  status when using the twister2 .open() and .close() methods.
- Bumped requirements to allow any version of Twisted 16.x