### PR TITLE
NetDevices loader plugins can now customize behavior of NetDevices

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from trigger import release as __version__
 requires = [
     'IPy>=0.73',
     'cryptography==1.4',
-    'Twisted>=15.4.0,<17.0.0',
+    'Twisted>=15.5.0,<17.0.0',
     'crochet==1.5.0',
     'mock==2.0.0',
     'pyasn1', # Twisted conch needs this, but doesn't say so

--- a/tests/test_netdevices.py
+++ b/tests/test_netdevices.py
@@ -115,6 +115,12 @@ class TestNetDevicesWithAcls(unittest.TestCase):
         # Case-insensitive attr *and* value
         self.assertEqual(expected, self.nd.match(SITE='NONE'))
 
+    def test_reload(self):
+        """Test the .reload() method."""
+        nd = self.nd
+        nd.reload()
+        self.assertEqual(nd, self.nd)
+
     def tearDown(self):
         _reset_netdevices()
 

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 6, 'rc3')
+__version__ = (1, 6, 'rc4')
 
 full_version = '.'.join(str(x) for x in __version__[0:3]) + \
                ''.join(__version__[3:])

--- a/trigger/netdevices/loader.py
+++ b/trigger/netdevices/loader.py
@@ -20,16 +20,13 @@ loader is responsible for setting this when it is initialized.
 This code is based on Django's template loader code: http://bit.ly/WWOLU3
 """
 
-__author__ = 'Jathan McCollum'
-__maintainer__ = 'Jathan McCollum'
-__email__ = 'jathan.mccollum@teamaol.com'
-__copyright__ = 'Copyright 2013, AOL Inc.'
-__version__ = '1.0'
+from collections import namedtuple
+
+from twisted.python import log
 
 from trigger.exceptions import ImproperlyConfigured, LoaderFailed
 from trigger.utils.importlib import import_module
 from trigger.conf import settings
-from twisted.python import log
 
 
 # Exports
@@ -118,6 +115,11 @@ def find_data_loader(loader):
     else:
         raise ImproperlyConfigured('Loader does not define a "load_data" callable data source loader.')
 
+
+#: Namedtuple that holds loader instance and device metadata
+LoaderMetadata = namedtuple('LoaderMetadata', 'loader metadata')
+
+
 def load_metadata(data_source, **kwargs):
     """
     Iterate thru data loaders to load metadata.
@@ -131,6 +133,9 @@ def load_metadata(data_source, **kwargs):
 
     :param kwargs:
         Optional keyword arguments you wish to pass to the Loader.
+
+    :returns:
+        `~trigger.netdevices.loader.LoaderMetadata` instance
     """
     # Iterate and build a loader callables, call them, stop when we get data.
     tried = []
@@ -154,7 +159,7 @@ def load_metadata(data_source, **kwargs):
             # Successfully parsed (we hope)
             if data is not None:
                 log.msg('LOADERS TRIED: %r' % tried)
-                return data
+                return LoaderMetadata(loader, data)
             else:
                 tried.append(loader)
                 continue


### PR DESCRIPTION
- A new `NetDevices.add_device()` method has been added to provide a
  cleaner interface to adding new NetDevice objects to a NetDevices
  instance.
- A new `NetDevices.reload()` method has been added to quickly and
  easily reset the state of a NetDevices instance.
- The `BaseLoader` plugin instance is now stored on the NetDevices
  instance so that it can provide the overloaded behaviors.
- `NetDevices.set_loader()` is used to attach the BaseLoader object
- On population, if an incoming object is already a NetDevice, the
  processing phase is skipped (implying that because you passed in a
  NetDevice you're declaring the object's state).
- The following `NetDevices` methods can now be customized by
  `BaseLoader` plugins:
  - `NetDevices.find()` to customize single device lookup
  - `NetDevices.match()` to customize keyword-argument lookup of devices
    - If `skip_loader=True` is passed, the built-in method will be
      called instead.
  - `NetDevices.all()` to customize retrieval of all device objects
  - `NetDevices._dict` to deeply customize the behavior of how NetDevice
    objects are stored internally.
- Raised minimum required version of Twisted to 15.5.0 because of support for new SSH key exchanges required for Cumulus Linux support.

Not included (yet):

- Unit tests for pluggable behavior.
- Documentation