### PR TITLE
Updated XMLRPC service to work w/ Twisted 16.4.0+ and SSH bugfix.

### DIFF
--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 6, 'rc4')
+__version__ = (1, 6, 'rc5')
 
 full_version = '.'.join(str(x) for x in __version__[0:3]) + \
                ''.join(__version__[3:])

--- a/trigger/utils/network.py
+++ b/trigger/utils/network.py
@@ -4,21 +4,26 @@
 Functions that perform network-based things like ping, port tests, etc.
 """
 
-__author__ = 'Jathan McCollum, Eileen Watson'
-__maintainer__ = 'Jathan McCollum'
-__email__ = 'jathan@gmail.com'
-__copyright__ = 'Copyright 2009-2013, AOL Inc.; 2013-2014 Salesforce.com'
-
 import os
 import subprocess
 import shlex
-import re
 import socket
 import telnetlib
+
 from trigger.conf import settings
+
 
 # Exports
 __all__ = ('ping', 'test_tcp_port', 'test_ssh', 'address_is_internal')
+
+
+# Constants
+# SSH version strings used to validate SSH banners.
+SSH_VERSION_STRINGS = (
+    'SSH-1.99',
+    'SSH-2.0',
+    'dcos_sshd run in non-FIPS mode',  # Cisco Nexus not in FIPS mode
+)
 
 
 # Functions
@@ -97,7 +102,7 @@ def test_tcp_port(host, port=23, timeout=5, check_result=False,
     return True
 
 
-def test_ssh(host, port=22, timeout=5, version=('SSH-1.99', 'SSH-2.0')):
+def test_ssh(host, port=22, timeout=5, version=SSH_VERSION_STRINGS):
     """
     Connect to a TCP port and confirm the SSH version. Defaults to SSHv2.
 


### PR DESCRIPTION
- XMLRPC service includes new options for generation and storage of the
  SSH host key for the SSH manhole
- Bugfix in `trigger.twister` preventing SSH connections to devices
  running Cisco Nexus with FIPS mode disabled. This also addresses the
  case in which a device sends any other text prior to sending the
  SSH version banner.
- Enhancement to `trigger.utils.network.test_ssh` to support extra SSH
  banners in the event that a Cisco Nexus w/ FIPS mode disabled is
  encountered that would otherwise cause an SSH connection test to fail.