### PR TITLE
Fixed TextFSM Commando Multiple Devices Bug.

### DIFF
--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import mock
+from collections import defaultdict
 from trigger.netdevices import NetDevices
 from trigger.cmds import Commando
 from trigger.utils.templates import *
@@ -133,7 +134,7 @@ class CheckTemplates(unittest.TestCase):
         self.assertTrue(len(data) > 0)
         self.assertTrue(isinstance(data, list))
         self.assertTrue(isinstance(data[0], str))
-        self.assertTrue(isinstance(commando.parsed_results, dict))
+        self.assertTrue(isinstance(commando.parsed_results, defaultdict))
         self.assertEquals(commando.parsed_results.popitem()[1]["show version"]["hardware"], ['CSR1000V'])
 
     def testCommandoResultsBad(self):

--- a/trigger/cmds.py
+++ b/trigger/cmds.py
@@ -446,7 +446,7 @@ class Commando(object):
 
             ret.append(results[idx])
 
-        self.parsed_results = dict(self.parsed_results)
+        self.parsed_results[device.nodeName] = dict(self.parsed_results)
         return ret
 
     def parse(self, results, device, commands=None):


### PR DESCRIPTION
This fixes a bug in the textfsm results binding command where given multiple devices in a Commando device_list, the parsed results clobber the parsed_results variable instead of the expected behaviour of a list of dicts keyed by the devices' hostname containing the parsed results.