### PR TITLE
Fixed TextFSM Commando Multiple Devices Bug.

### DIFF
--- a/trigger/cmds.py
+++ b/trigger/cmds.py
@@ -528,7 +528,7 @@ class Commando(object):
         """
         devname = str(device)
         log.msg("Appending results for %r: %r" % (devname, results))
-        self.parsed_results[devname].update(results)
+        self.parsed_results[devname] = results
         return True
 
     def store_results(self, device, results):


### PR DESCRIPTION
This fixes a bug in the textfsm results binding command where given
multiple devices in a Commando device_list, the parsed results clobber
the parsed_results variable instead of the expected behaviour of a list
of dicts keyed by the devices' hostname containing the parsed results.