### PR TITLE
Fix #313 - Use pyparsing~=2.2.0 for compat w/ setuptools>=34.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requires = [
     'crochet==1.5.0',
     'mock==2.0.0',
     'pyasn1', # Twisted conch needs this, but doesn't say so
-    'pyparsing==1.5.7',
+    'pyparsing~=2.2.0',
     'pytz',
     'SimpleParse',
     'gtextfsm',


### PR DESCRIPTION
Apparently setuptools get's angry because setuptools was previously vendoring its own internal version of pyparsing and now as of 34.x it does not. So this pinned version of pyparsing was conflicting w/ the newer version of setuptools.