### PR TITLE
fix cryptography requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from trigger import release as __version__
 # Names of required packages
 requires = [
     'IPy>=0.73',
-    'cryptography==1.4',
+    'cryptography>=1.4',
     'Twisted>=15.5.0,<17.0.0',
     'crochet==1.5.0',
     'mock==2.0.0',


### PR DESCRIPTION
current cryptography version from Pypi is at 2.3.0. Hence it can not be installed and breaks other packages like paramiko which is used for SSH to device.