### PR TITLE
Replace usage of `mktemp` with `mkstemp`

### DIFF
--- a/bin/check_syntax
+++ b/bin/check_syntax
@@ -56,7 +56,8 @@ def main():
             print ""
 
 if __name__ == '__main__':
-    tmpfile = tempfile.mktemp()+'_parsing_check'
+    fd, tmpfile = tempfile.mkstemp(suffix='_parsing_check')
     log.startLogging(open(tmpfile, 'a'), setStdout=False)
     log.msg('User %s (uid:%d) executed "%s"' % (os.environ['LOGNAME'], os.getuid(), ' '.join(sys.argv)))
     main()
+    os.close(fd)

--- a/bin/load_acl
+++ b/bin/load_acl
@@ -780,7 +780,8 @@ def main():
     log.msg('Elapsed time: %s' % min_sec(time.time() - start))
 
 if __name__ == '__main__':
-    tmpfile = tempfile.mktemp()+'_load_acl'
+    fd, tmpfile = tempfile.mkstemp(suffix='_load_acl')
     log.startLogging(open(tmpfile, 'a'), setStdout=False)
     log.msg('User %s (uid:%d) executed "%s"' % (os.environ['LOGNAME'], os.getuid(), ' '.join(sys.argv)))
     main()
+    os.close(fd)

--- a/tools/prepend_acl_dot
+++ b/tools/prepend_acl_dot
@@ -77,8 +77,9 @@ def main():
                 adb.remove_acl(dev, acl_name)
 
 if __name__ == '__main__':
-    tmpfile = tempfile.mktemp()+'_prepend_acl_dot'
+    fd, tmpfile = tempfile.mkstemp(suffix='_prepend_acl_dot')
     print "Logging to %s" % tmpfile
     log.startLogging(open(tmpfile, 'a'), setStdout=False)
     log.msg('User %s (uid:%d) executed "%s"' % (os.environ['LOGNAME'], os.getuid(), ' '.join(sys.argv)))
     main()
+    os.close(fd)

--- a/trigger/acl/tools.py
+++ b/trigger/acl/tools.py
@@ -446,12 +446,13 @@ def update_expirations(matches, numdays=DEFAULT_EXPIRE):
 
 def write_tmpacl(acl, process_name='_tmpacl'):
     """Write a temporary file to disk from an Trigger acl.ACL object & return the filename"""
-    tmpfile = tempfile.mktemp() + process_name
+    fd, tmpfile = tempfile.mkstemp(suffix=process_name)
     f = open(tmpfile, 'w')
     for x in acl.output(acl.format, replace=True):
         f.write(x)
         f.write('\n')
     f.close()
+    os.close(fd)
 
     return tmpfile
 
@@ -549,7 +550,7 @@ class ACLScript:
                    }.iteritems():
             if len(v) == 0:
                 continue
-            tmpf = tempfile.mktemp() + '_genacl'
+            fd, tmpf = tempfile.mkstemp(suffix='_genacl')
             self.tempfiles.append(tmpf)
             try:
                 f = open(tmpf,'w')
@@ -559,6 +560,7 @@ class ACLScript:
             for x in v:
                 f.write('%s\n' % x.strNormal())
             f.close()
+            os.close(fd)
 
             argz.append('%s %s' % (k,tmpf))
 

--- a/trigger/contrib/docommand/core.py
+++ b/trigger/contrib/docommand/core.py
@@ -80,7 +80,7 @@ def main(action_class=None):
         log.startLogging(sys.stdout, setStdout=False)
 
     # Always log all the activity to a file!
-    logfile = tempfile.mktemp() + '_run_cmds'
+    fd, logfile = tempfile.mkstemp(suffix='_run_cmds')
     log.startLogging(open(logfile, 'a'), setStdout=False)
     log.msg('User %s (uid:%d) executed "%s"' % (os.environ['LOGNAME'],
         os.getuid(), ' '.join(sys.argv)))
@@ -90,6 +90,7 @@ def main(action_class=None):
     work = get_jobs(opts)
     results = do_work(work, action_class)
     print_results(results)
+    os.close(fd)
     print '\nDone.'
 
 def get_jobs(opts):


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [tools.py](https://github.com/trigger/trigger/blob/develop/trigger/acl/tools.py#L449), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the Python documentation. iCR suggested that a temporary file should be created using `mkstemp` which is a safe API. iCR replaced the usage of `mktemp` with `mkstemp`.

> In file: [core.py](https://github.com/trigger/trigger/blob/develop/trigger/contrib/docommand/core.py#L83), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the Python documentation. iCR suggested that a temporary file should be created using `mkstemp` which is a safe API. iCR replaced the usage of `mktemp` with `mkstemp`.

> In file: [load_acl](https://github.com/trigger/trigger/blob/develop/bin/load_acl#L783), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the Python documentation. iCR suggested that a temporary file should be created using `mkstemp` which is a safe API. iCR replaced the usage of `mktemp` with `mkstemp`.

> In file: [check_syntax](https://github.com/trigger/trigger/blob/develop/bin/check_syntax#L59), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the Python documentation. iCR suggested that a temporary file should be created using `mkstemp` which is a safe API. iCR replaced the usage of `mktemp` with `mkstemp`.

> In file: [prepend_acl_dot](https://github.com/trigger/trigger/blob/develop/tools/prepend_acl_dot#L80), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the Python documentation. iCR suggested that a temporary file should be created using `mkstemp` which is a safe API. iCR replaced the usage of `mktemp` with `mkstemp`.

### Related Documentation(s)
- [Deprecated functions and variables](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp)
- [`mkstemp` usage](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp)


## Changes
- Replaced the method `mktemp()` with a safer option - `mkstemp()`
- Closed the file descriptors so that it doesn't lead to file descriptor leaks.


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
