### PR TITLE
fix(release): checkout version-bumped tag for PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     environment: release
     outputs:
       released: ${{ steps.release.outputs.released }}
+      tag: ${{ steps.release.outputs.tag }}
 
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +52,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # When semantic-release creates a version, check out the tag it created
+          # (which has the bumped version). For direct tag pushes, use the pushed ref.
+          ref: ${{ needs.release.outputs.tag || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3


### PR DESCRIPTION
## Summary
- The publish job was checking out the PR merge commit instead of the semantic-release version-bump commit, causing `uv build` to produce artifacts with the old version (2.0.0 instead of 2.0.1)
- Pass the `tag` output from the semantic-release job and use it as the `ref` in the publish job's checkout step
- For direct tag pushes, falls back to `github.ref` (existing behavior)

## Root cause
`actions/checkout@v4` without a `ref` checks out `GITHUB_SHA`, which is the commit that triggered the workflow (the PR merge). Semantic-release creates a *new* commit with the version bump and tags it, but the publish job never saw that commit.

## Test plan
- [ ] Merge this PR and verify the release workflow builds with the correct version
- [ ] Confirm PyPI publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)