### PR TITLE
fix(release): use RELEASE_TOKEN PAT to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for semantic-release
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -37,7 +37,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v9
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}
 
   publish:
     name: Build & Publish to PyPI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,6 @@ Supported vendors include:
 
 ## Branch Strategy
 
-- **`develop`**: Default branch, generally stable but not production-ready
-- **`master`**: Stable production-ready branch
-- Release tags: Specific versions available as tag branches (e.g., `v1.6.0`)
+- **`main`**: Primary branch for all development and releases. All PRs target `main`.
+- **Do NOT use or target the `develop` branch.** It is a legacy branch that is out of sync and should be ignored entirely.
+- Release tags: Specific versions available as tag branches (e.g., `v2.0.1`)


### PR DESCRIPTION
## Summary
- Use `RELEASE_TOKEN` PAT instead of `GITHUB_TOKEN` in the release workflow so semantic-release can push version bump commits and tags directly to `main` (bypassing the PR-required ruleset)
- Update `CLAUDE.md` branch strategy: `main` is the primary branch, `develop` is deprecated

## Context
The release workflow was failing with `GH013: Repository rule violations` because `GITHUB_TOKEN` can't push directly to protected branches. A PAT with bypass permissions resolves this.

## Test plan
- [ ] Verify `RELEASE_TOKEN` secret exists in repo settings (confirmed)
- [ ] Verify PAT owner is added as bypass actor in the `main` branch ruleset
- [ ] Merge this PR and confirm the Release workflow succeeds on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)