### PR TITLE
fix(release): skip PyPI upload if version already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,3 +72,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true
+          skip-existing: true


### PR DESCRIPTION
## Summary
- Add `skip-existing: true` to the PyPI publish step so re-runs don't fail when a version was already uploaded

## Context
The v2.0.2 release partially succeeded (published to PyPI) before the git push failed due to branch protection. When the workflow re-ran after the RELEASE_TOKEN fix, the publish job failed with `HTTPError: 400 Bad Request - File already exists`. This flag prevents that scenario from causing a red X.

## Test plan
- [ ] Merge and verify the next release workflow run doesn't fail on duplicate uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)