### PR TITLE
docs: add git worktrees guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,15 @@ Supported vendors include:
 - **Vendor detection**: Based on device metadata, not auto-discovery; metadata must be accurate
 - **Test isolation**: Tests use conftest.py to set environment variables for mock data
 
+## Git Worktrees
+
+Always use git worktrees for feature branches. Worktrees live in `.worktrees/` (already gitignored).
+
+```bash
+# Create a worktree for a new feature branch
+git worktree add .worktrees/<branch-name> -b <branch-name>
+```
+
 ## Branch Strategy
 
 - **`main`**: Primary branch for all development and releases. All PRs target `main`.


### PR DESCRIPTION
## Summary
- Adds a "Git Worktrees" section to CLAUDE.md instructing Claude Code to always use `.worktrees/` for feature branches

## Test plan
- [x] Verify `.worktrees/` is already in `.gitignore`
- [ ] Confirm Claude Code follows the guidance in future sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)