### PR TITLE
fix(security): replace deprecated tempfile.mktemp with mkstemp

### DIFF
--- a/bin/check_syntax
+++ b/bin/check_syntax
@@ -55,7 +55,7 @@ def main():
             print ""
 
 if __name__ == '__main__':
-    tmpfile = tempfile.mktemp()+'_parsing_check'
-    log.startLogging(open(tmpfile, 'a'), setStdout=False)
+    fd, tmpfile = tempfile.mkstemp(suffix='_parsing_check')
+    log.startLogging(os.fdopen(fd, 'a'), setStdout=False)
     log.msg('User %s (uid:%d) executed "%s"' % (os.environ['LOGNAME'], os.getuid(), ' '.join(sys.argv)))
     main()

--- a/bin/load_acl
+++ b/bin/load_acl
@@ -779,7 +779,7 @@ def main():
     log.msg('Elapsed time: %s' % min_sec(time.time() - start))
 
 if __name__ == '__main__':
-    tmpfile = tempfile.mktemp()+'_load_acl'
-    log.startLogging(open(tmpfile, 'a'), setStdout=False)
+    fd, tmpfile = tempfile.mkstemp(suffix='_load_acl')
+    log.startLogging(os.fdopen(fd, 'a'), setStdout=False)
     log.msg('User %s (uid:%d) executed "%s"' % (os.environ['LOGNAME'], os.getuid(), ' '.join(sys.argv)))
     main()

--- a/tools/prepend_acl_dot
+++ b/tools/prepend_acl_dot
@@ -77,8 +77,8 @@ def main():
                 adb.remove_acl(dev, acl_name)
 
 if __name__ == '__main__':
-    tmpfile = tempfile.mktemp()+'_prepend_acl_dot'
+    fd, tmpfile = tempfile.mkstemp(suffix='_prepend_acl_dot')
     print "Logging to %s" % tmpfile
-    log.startLogging(open(tmpfile, 'a'), setStdout=False)
+    log.startLogging(os.fdopen(fd, 'a'), setStdout=False)
     log.msg('User %s (uid:%d) executed "%s"' % (os.environ['LOGNAME'], os.getuid(), ' '.join(sys.argv)))
     main()


### PR DESCRIPTION
## Summary

- Replace unsafe `tempfile.mktemp()` with `tempfile.mkstemp()` in the remaining `bin/` and `tools/` scripts (`check_syntax`, `load_acl`, `prepend_acl_dot`)
- Uses `os.fdopen(fd)` to properly manage the file descriptor, consistent with the pattern already established in `trigger/acl/tools.py` and `trigger/contrib/docommand/core.py`
- Eliminates TOCTOU race condition vulnerability from deprecated `mktemp()` API

## Attribution

Based on PR #335 by @nydelzaf (Ataf Fazledin Ahamed, OpenRefactory/OpenSSF Alpha-Omega). The original PR targeted the legacy `develop` branch. Two of the five fixes (`trigger/acl/tools.py`, `trigger/contrib/docommand/core.py`) were already applied in PR #339 (ruff modernization). This PR applies the remaining three fixes modernized against `main`.

## References

- Original PR: #335
- Python docs: [tempfile.mktemp (deprecated)](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp)
- Python docs: [tempfile.mkstemp](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp)

## Test plan

- [ ] Verify no `mktemp()` calls remain in the codebase
- [ ] Confirm `mkstemp()` pattern matches existing usage in `trigger/acl/tools.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)