### PR TITLE
docs: update README and docs to reflect main branch and remove stale links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # What is Trigger?
 
 [![CI](https://github.com/trigger/trigger/workflows/CI/badge.svg)](https://github.com/trigger/trigger/actions/workflows/ci.yml)
-[![Join the chat at https://gitter.im/trigger/trigger](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/trigger/trigger?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Trigger is a robust network automation toolkit written in Python that was
 designed for interfacing with network devices and managing network
@@ -42,15 +41,8 @@ network devices with ease. Here are some of things that make Trigger tick:
 + Flexible access-list & firewall policy parser that can test access if access
   is permitted, or easily convert ACLs from one format to another.
 + Detailed support for timezones and maintenance windows.
++ Import your metadata from an existing [RANCID](http://shrubbery.net/rancid/) installation or a CSV file to get up-and-running quickly.
 + A suite of tools for simplifying many common tasks.
-
-New in version 1.2:
-
-+ Import your metadata from an existing [RANCID](http://shrubbery.net/rancid/) installation to get up-and-running quickly!
-
-New in version 1.3:
-
-+ Import your metadata from a CSV file and get up-and-running even quicker!
 
 ## Getting Started
 
@@ -105,21 +97,13 @@ See the [Migration Guide](https://trigger.readthedocs.io/en/latest/migration.htm
 
 ### Before you begin
 
-+ The [develop](https://github.com/trigger/trigger/tree/develop) branch is
-  the default branch that will be active when you clone this repository. While
-  it is generally stable this branch is not considered production-ready. Use at
-  your own risk!
-+ The [master](https://github.com/trigger/trigger/tree/master) branch is
-  the stable branch, and will reflect the latest production-ready changes. It
-  is recommended that this is the branch you use if you are installing Trigger
-  for the first time.
-+ Each point release of Trigger is maintained as a [tag branch](https://github.com/trigger/trigger/tags). If you require a
++ The [main](https://github.com/trigger/trigger/tree/main) branch is the
+  primary branch for all development and releases. All pull requests target
+  `main`.
++ Each point release of Trigger is maintained as a [tag](https://github.com/trigger/trigger/tags). If you require a
   specific Trigger version, please refer to these.
 
 ### Get in touch!
 
-If you run into any snags, have questions, feedback, or just want to talk shop:
-[contact us](https://trigger.readthedocs.io/en/latest/#getting-help)!
-
-**Pro tip**: Find us on IRC at `#trigger` on Freenode
-([irc://irc.freenode.net/trigger](irc://irc.freenode.net/trigger)).
+If you run into any snags, have questions, feedback, or just want to talk shop,
+please open an issue on [GitHub Issues](https://github.com/trigger/trigger/issues).

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -276,7 +276,7 @@ New Features
 
 + Remote execution on Avocent console servers is now officially supported.
 + Example `normalizer
-  <https://github.com/trigger/trigger/tree/develop/examples/normalizer>`_
+  <https://github.com/trigger/trigger/tree/main/examples/normalizer>`_
   project added to the ``examples`` directory at the root of the repository.
 
 Enhancements

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -119,23 +119,16 @@ For more information, see the `CLAUDE.md <../CLAUDE.md>`_ development guide.
 Branching/Repository Layout
 ===========================
 
-While Trigger's development methodology isn't set in stone yet, the following
-items detail how we currently organize the Git repository and expect to perform
-merges and so forth. This will be chiefly of interest to those who wish to
-follow a specific Git branch instead of released versions, or to any
-contributors.
+All development happens on the ``main`` branch. There is no separate
+``develop`` or ``master`` branch. Pull requests should always target ``main``
+and are merged using rebase merges (no merge commits).
 
-* Completed feature work is merged into the ``master`` branch, and once enough
-  new features are done, a new release branch is created and optionally used to
-  create prerelease versions for testing -- or simply released as-is.
-* While we try our best not to commit broken code or change APIs without
-  warning, as with many other open-source projects we can only have a guarantee
-  of stability in the release branches. Only follow ``develop`` (or, even worse,
-  feature branches!) if you're willing to deal with a little pain.
-* Bugfixes are to be performed on release branches and then merged into
-  ``develop`` so that ``develop`` is always up-to-date (or nearly so; while it's
-  not mandatory to merge after every bugfix, doing so at least daily is a good
-  idea.)
+Releases are cut by tagging a commit on ``main`` (e.g. ``v2.0.1``). If you
+need a specific version, check out the corresponding tag.
+
+We use `conventional commits <https://www.conventionalcommits.org/>`_
+(enforced via prek/pre-commit hooks) which drive automated semantic
+versioning.
 
 Releases
 ========

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -204,7 +204,7 @@ Basic Configuration
 
 .. warning::
     For these steps you'll need to download the `Trigger tarball
-    <https://github.com/trigger/trigger/tarball/develop>`_, expand it, and then
+    <https://github.com/trigger/trigger/tarball/main>`_, expand it, and then
     navigate to the root directory (the same directory in which you'll find
     ``setup.py``).
 
@@ -288,7 +288,7 @@ Verifying Functionality
 
 .. warning::
     For these steps you'll still need to be at the root directory of the
-    `Trigger tarball <https://github.com/trigger/trigger/tarball/develop>`_. If
+    `Trigger tarball <https://github.com/trigger/trigger/tarball/main>`_. If
     you haven't already, download it,  expand it, and then navigate to the root
     directory (the same directory in which you'll find ``setup.py``).
 


### PR DESCRIPTION
## Summary

- Remove defunct Gitter badge and IRC/Freenode contact info from README; point to GitHub Issues instead
- Rewrite "Before you begin" and branching docs to reflect `main`-only branch strategy
- Fold old "New in version 1.2/1.3" notes into Key Features list
- Update tarball URLs and example links from `develop` to `main`

## Test plan

- [ ] Verify no remaining references to `develop` or `master` as branch names in changed files
- [ ] Confirm only documentation files were modified (no code changes)
- [ ] Spot-check that links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)