### PR TITLE
refactor: enable five single-violation ruff lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ ignore = [
     "B018",     # useless-expression (test assertions)
 
     # --- Pre-commit specific ignores ---
-    "PLW1641",  # __hash__ implementation (false positive, requires __eq__ impl)
     "PT028",    # pytest parameter defaults (false positive, not pytest functions)
 
     # --- Docstring exceptions (not enforcing coverage/style) ---
@@ -150,7 +149,6 @@ ignore = [
     "D404",     # docstring-starts-with-this
 
     # --- Complexity (deep refactoring territory) ---
-    "PLR0911",  # too-many-return-statements
     "PLR0912",  # too-many-branches
     "PLR0913",  # too-many-arguments
     "PLR0915",  # too-many-statements
@@ -160,9 +158,6 @@ ignore = [
     # --- Security false positives for network toolkit ---
     "S101",     # assert (used in tests)
     "S105",     # hardcoded-password-string (false positives)
-    "S110",     # try-except-pass
-    "S112",     # try-except-continue
-    "S314",     # suspicious-xml-element-tree-usage
     "S603",     # subprocess-without-shell-equals-true
     "S605",     # start-process-with-a-shell (fix manually)
     "S606",     # start-process-with-no-shell

--- a/trigger/contrib/xmlrpc/server.py
+++ b/trigger/contrib/xmlrpc/server.py
@@ -134,7 +134,7 @@ class TriggerXMLRPCServer(xmlrpc.XMLRPC):
                 module = importlib.import_module(mod_name, __name__)
             except NameError as msg:
                 log.msg(f"NameError: {msg}")
-            except:
+            except:  # noqa: S110
                 pass
 
         if not module:

--- a/trigger/netdevices/__init__.py
+++ b/trigger/netdevices/__init__.py
@@ -163,7 +163,7 @@ def device_match(name, production_only=True):
 
 
 # Classes
-class NetDevice:
+class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
     """An object that represents a distinct network device and its metadata.
 
     Almost all of the attributes are populated by
@@ -356,7 +356,7 @@ class NetDevice:
 
         return []
 
-    def _set_commit_commands(self):
+    def _set_commit_commands(self):  # noqa: PLR0911 - vendor dispatch
         """Return the proper "commit" command. (e.g. write mem, etc.)."""
         if self.is_ioslike():
             return self._ioslike_commit()

--- a/trigger/netdevices/loaders/filesystem.py
+++ b/trigger/netdevices/loaders/filesystem.py
@@ -65,7 +65,7 @@ class XMLLoader(BaseLoader):
     def get_data(self, data_source):
         # Parsing the complete file into a tree once and extracting outthe
         # device nodes is faster than using iterparse(). Curses!!
-        xml = ET.parse(data_source).findall("device")
+        xml = ET.parse(data_source).findall("device")  # noqa: S314 - trusted local data
 
         # This is a generator within a generator. Trust me, it works in _populate()
         # Python 3.9+: getchildren() removed, use list(node) instead

--- a/trigger/utils/notifications/handlers.py
+++ b/trigger/utils/notifications/handlers.py
@@ -116,7 +116,7 @@ def notify(*args, **kwargs):
         # print 'Sending %s, %s to %s' % (args, kwargs, handler)
         try:
             result = handler(*args, **kwargs)
-        except Exception:  # noqa: PERF203
+        except Exception:  # noqa: PERF203, S112
             # print 'Got exception: %s' % err
             continue
         else:


### PR DESCRIPTION
## Summary

Remove five rules from the global ruff ignore list that each had only a single violation, replacing them with targeted `# noqa` comments on the intentional cases:

- **PLR0911** (too-many-return-statements): vendor dispatch in `_set_commit_commands`
- **PLW1641** (missing `__hash__`): `NetDevice` is mutable, intentionally unhashable
- **S110** (try-except-pass): catch-all in xmlrpc server module loader
- **S112** (try-except-continue): resilient notification handler dispatch
- **S314** (suspicious XML parsing): trusted local device metadata files

These rules are now enforced project-wide to prevent new violations. No behavioral or API changes. `refactor:` commit only — no release triggered.

## Test plan

- [x] `ruff check trigger/ tests/ configs/` passes clean
- [x] `ruff format --check trigger/ tests/ configs/` passes clean
- [x] All 169 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-configuration-only change with localized suppressions; runtime behavior is unchanged aside from added comments.
> 
> **Overview**
> Tightens linting by removing five codes (`PLW1641`, `PLR0911`, `S110`, `S112`, `S314`) from the global Ruff ignore list in `pyproject.toml`, making them enforced across the repo.
> 
> Adds targeted `# noqa` annotations at the few intentional violations: a catch-all `except: pass` in `trigger/contrib/xmlrpc/server.py`, resilient handler dispatch `except: continue` in `trigger/utils/notifications/handlers.py`, trusted local XML parsing in `trigger/netdevices/loaders/filesystem.py`, and explicit ignores for `NetDevice` hashability and vendor-dispatch returns in `trigger/netdevices/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 868ea9d65ff013f7b620a5150d406486d6dc204c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->