### PR TITLE
refactor: enable six ruff lint rules (F402, E721, F811, S603, S608, S105)

### DIFF
--- a/configs/trigger_settings.py
+++ b/configs/trigger_settings.py
@@ -30,7 +30,7 @@ TACACSRC_USE_PASSPHRASE = False
 
 # Use this passphrase to encrypt credentials.CHANGE THIS IN YOUR FILE BEFORE
 # USING THIS IN YOUR ENVIRONMENT.
-TACACSRC_PASSPHRASE = "bacon is awesome, son."  # NYI
+TACACSRC_PASSPHRASE = "bacon is awesome, son."  # noqa: S105 - example config
 
 # Default login realm to store user credentials (username, password) for
 # general use within the .tacacsrc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,14 +117,11 @@ ignore = [
     # --- Kept from v2.0.0 baseline ---
     "E402",     # module-import-not-at-top-of-file
     "E501",     # line-too-long (handled by formatter)
-    "E721",     # type-comparison (existing code style)
     "E722",     # bare-except (intentional in many places)
     "E741",     # ambiguous-variable-name (existing code style)
     "F401",     # unused-import (may be used dynamically)
-    "F402",     # import-shadowed-by-loop-var
     "F403",     # undefined-local-with-import-star
     "F405",     # undefined-local-with-import-star-usage
-    "F811",     # redefined-while-unused
     "F821",     # undefined-name
     "UP031",    # printf-string-formatting
 
@@ -157,11 +154,8 @@ ignore = [
 
     # --- Security false positives for network toolkit ---
     "S101",     # assert (used in tests)
-    "S105",     # hardcoded-password-string (false positives)
-    "S603",     # subprocess-without-shell-equals-true
     "S605",     # start-process-with-a-shell (fix manually)
     "S606",     # start-process-with-no-shell
-    "S608",     # hardcoded-sql-expression
 
     # --- Other ---
     "RUF012",   # mutable-class-default (too many in device metadata)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -748,8 +748,8 @@ class CheckTriggerIP(unittest.TestCase):
         # Until we fix inactive testing, this is legit
         self.assertTrue(obj in self.test_net)
 
-    def testInactive(self):
-        """Test an inactive IP object"""
+    def testInactiveAndNegated(self):
+        """Test an inactive and negated IP object"""
         test = "inactive: 1.2.3.4/32 except"
         obj = acl.TIP(test)
         self.assertEqual(str(obj), test)

--- a/trigger/bin/gnng.py
+++ b/trigger/bin/gnng.py
@@ -193,7 +193,7 @@ def write_sqldb(sqlfile, dev, rows):
             VALUES (
                 '{dev}', '{iface}', '{addrs}',
                 '{snets}', '{inacl}', '{outacl}', '{desc}'
-            );""",
+            );""",  # noqa: S608 - local sqlite, not user input
         )
 
     connection.commit()

--- a/trigger/conf/__init__.py
+++ b/trigger/conf/__init__.py
@@ -75,7 +75,7 @@ class Settings(BaseSettings):
         for setting in dir(mod):
             if setting == setting.upper():
                 setting_value = getattr(mod, setting)
-                if setting in tuple_settings and type(setting_value) == str:
+                if setting in tuple_settings and isinstance(setting_value, str):
                     setting_value = (
                         setting_value,
                     )  # In case the user forgot the comma.

--- a/trigger/contrib/commando/__init__.py
+++ b/trigger/contrib/commando/__init__.py
@@ -159,7 +159,7 @@ class CommandoApplication(Commando):
 
         cmd_list = []
         for cmd, res in itertools.zip_longest(commands, results):
-            if type(Element("")) == type(cmd):
+            if isinstance(cmd, Element):
                 # XML must die a very horrible death
                 cmd = ET.tostring(cmd)  # noqa: PLW2901
             cmdobj = dict(command=cmd, result=res)

--- a/trigger/contrib/xmlrpc/server.py
+++ b/trigger/contrib/xmlrpc/server.py
@@ -21,7 +21,7 @@ from twisted.python import log
 from twisted.web import server, xmlrpc
 
 from trigger.contrib.commando import CommandoApplication
-from trigger.utils import importlib
+from trigger.utils import importlib as importlib  # noqa: F811
 
 # Enable Deferred debuging if ``DEBUG`` is set.
 if os.getenv("DEBUG"):

--- a/trigger/netdevices/__init__.py
+++ b/trigger/netdevices/__init__.py
@@ -472,7 +472,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
         return self.nodeName.split(".", 1)[0]
 
     @property
-    def os(self):
+    def os(self):  # noqa: F811 - property name intentionally shadows os module
         vendor_mapping = settings.TEXTFSM_VENDOR_MAPPINGS
         try:
             oss = vendor_mapping[self.vendor]

--- a/trigger/netdevices/loaders/filesystem.py
+++ b/trigger/netdevices/loaders/filesystem.py
@@ -120,7 +120,7 @@ class SQLiteLoader(BaseLoader):
 
         # And the devices. This is a list of tuples whose values match the indexes
         # of the column names.
-        devfetch = cursor.execute(f"select * from {table_name}")
+        devfetch = cursor.execute(f"select * from {table_name}")  # noqa: S608 - trusted config value
         devrows = devfetch.fetchall()
 
         # Another generator within a generator, which structurally is a list of

--- a/trigger/tacacsrc.py
+++ b/trigger/tacacsrc.py
@@ -182,7 +182,7 @@ def validate_credentials(creds=None):
 
     # If it isn't set or it's a string, or less than 1 or more than 3 items,
     # get from .tacacsrc
-    if (not creds) or (type(creds) == str) or (len(creds) not in (2, 3)):
+    if (not creds) or isinstance(creds, str) or (len(creds) not in (2, 3)):
         log.msg("Creds not valid, fetching from .tacacsrc...")
         tcrc = Tacacsrc()
         return tcrc.creds.get(realm, get_device_password(realm, tcrc))
@@ -487,9 +487,9 @@ class Tacacsrc:
             ),
         ]
 
-        for realm, (uname, pwd, _) in self.creds.items():
+        for realm, (uname, password, _) in self.creds.items():
             out.append(f"{realm}_uname_ = {self._encrypt_old(uname)}")
-            out.append(f"{realm}_pwd_ = {self._encrypt_old(pwd)}")
+            out.append(f"{realm}_pwd_ = {self._encrypt_old(password)}")
 
         with Path(self.file_name).open("w+") as fd:
             fd.writelines(out)
@@ -522,9 +522,9 @@ class Tacacsrc:
             ),
         ]
 
-        for realm, (uname, pwd, _) in self.creds.items():
+        for realm, (uname, password, _) in self.creds.items():
             out.append(f"{realm}_uname_ = {uname}")
-            out.append(f"{realm}_pwd_ = {pwd}")
+            out.append(f"{realm}_pwd_ = {password}")
 
         self.rawdata = out
         self._encrypt_and_write()

--- a/trigger/utils/network.py
+++ b/trigger/utils/network.py
@@ -43,7 +43,7 @@ def ping(host, count=1, timeout=5):
     ping_command = "ping -q -c%d -W%d %s" % (count, timeout, host)
     status = None
     with Path(os.devnull).open("w") as devnull_fd:
-        status = subprocess.call(
+        status = subprocess.call(  # noqa: S603
             shlex.split(ping_command),
             stdout=devnull_fd,
             stderr=devnull_fd,


### PR DESCRIPTION
## Summary

Remove six rules from the global ruff ignore list with targeted fixes and `# noqa` comments:

- **F402** (import-shadowed-by-loop-var): rename `pwd` loop var to `password` in `tacacsrc.py` to avoid shadowing `import pwd`
- **E721** (type-comparison): replace `type(x) == y` with `isinstance()` in 3 files
- **F811** (redefined-while-unused): rename duplicate `testInactive` to `testInactiveAndNegated` — this test was silently shadowed and never running; now runs as the 170th test. `# noqa` on two intentional cases (importlib override, `os` property)
- **S603** (subprocess-without-shell): `# noqa` on trusted subprocess calls
- **S608** (hardcoded-sql-expression): `# noqa` on local sqlite operations
- **S105** (hardcoded-password-string): `# noqa` on example/test config files

All rules now enforced project-wide. No behavioral or API changes. `refactor:` commit only — no release triggered.

## Test plan

- [x] `ruff check trigger/ tests/ configs/` passes clean
- [x] `ruff format --check trigger/ tests/ configs/` passes clean
- [x] All 170 tests pass (up from 169 — the previously shadowed test now runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily lint-enablement and mechanical refactors with no intended runtime behavior changes; main functional impact is that a previously-shadowed test now executes.
> 
> **Overview**
> Updates `pyproject.toml` to stop globally ignoring six Ruff rules (`E721`, `F402`, `F811`, `S603`, `S608`, `S105`) and instead address violations in code.
> 
> Fixes type-check comparisons by switching `type(...) == ...` to `isinstance(...)`, renames a shadowed variable in `trigger/tacacsrc.py`, and renames a duplicate test (`testInactiveAndNegated`) so it actually runs. Adds targeted `# noqa` annotations for intentional patterns: example hardcoded passphrase in `configs/trigger_settings.py`, trusted subprocess ping call, and local/trusted SQLite queries, plus two intentional name-shadowing cases (`trigger/contrib/xmlrpc/server.py` and `NetDevice.os`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00583b9e5c62dfe7524114a92e8216ceb8695dfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->