### PR TITLE
refactor: enable ruff D104, B018, PT028, D402 lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,22 +127,15 @@ ignore = [
 
     # --- Bugbear exceptions ---
     "B016",     # raise-literal (used intentionally in tests)
-    "B018",     # useless-expression (test assertions)
-
-    # --- Pre-commit specific ignores ---
-    "PT028",    # pytest parameter defaults (false positive, not pytest functions)
-
     # --- Docstring exceptions (not enforcing coverage/style) ---
     "D100",     # undocumented-public-module
     "D101",     # undocumented-public-class
     "D102",     # undocumented-public-method
     "D103",     # undocumented-public-function
-    "D104",     # undocumented-public-package
     "D105",     # undocumented-magic-method
     "D107",     # undocumented-public-init
     "D205",     # missing-blank-line-after-summary
     "D401",     # non-imperative-mood
-    "D402",     # signature-in-docstring
     "D404",     # docstring-starts-with-this
 
     # --- Complexity (deep refactoring territory) ---

--- a/trigger/__init__.py
+++ b/trigger/__init__.py
@@ -1,3 +1,5 @@
+"""Trigger: Network automation toolkit for managing network devices."""
+
 from importlib.metadata import PackageNotFoundError, version
 
 try:

--- a/trigger/acl/support.py
+++ b/trigger/acl/support.py
@@ -42,11 +42,7 @@ from trigger import exceptions
 from .dicts import *
 
 # Python 2/3 compatibility
-try:
-    unicode
-except NameError:
-    # Python 3
-    unicode = str
+unicode = str
 
 # Temporary resting place for comments, so the rest of the parser can
 # ignore them.  Yes, this makes the library not thread-safe.

--- a/trigger/bin/__init__.py
+++ b/trigger/bin/__init__.py
@@ -1,0 +1,1 @@
+"""CLI entry points for Trigger network automation tools."""

--- a/trigger/bin/load_acl.py
+++ b/trigger/bin/load_acl.py
@@ -419,7 +419,7 @@ def get_work(opts, args):
                 )
                 del work[dev]
             print("\nUse --bouncy to forcefully load on these devices anyway.")
-        print
+        print()
 
     # Display filtered acls
     for a in filtered_acls:

--- a/trigger/cmds.py
+++ b/trigger/cmds.py
@@ -1198,4 +1198,4 @@ def _dump_interfaces(idict):
                 print(str(info))
         else:
             print("might be shutdown")
-        print
+        print()

--- a/trigger/contrib/docommand/core.py
+++ b/trigger/contrib/docommand/core.py
@@ -80,7 +80,7 @@ __all__ = (
 
 # Functions
 def main(action_class=None):
-    """Void = main(CommandoClass action_class)."""
+    """Run the docommand main entry point with the given action class."""
     if action_class is None:
         sys.exit("You must specify a docommand action class.")
 
@@ -104,7 +104,7 @@ def main(action_class=None):
 
 
 def get_jobs(opts):
-    """List jobs = get_jobs(dict opts).
+    """Build a list of jobs from the given options.
 
     Based on which arguments are provided, figure out what is loaded/run on
     which devices and create a list of objects matching the 2::
@@ -155,7 +155,7 @@ def get_jobs(opts):
 
 
 def get_devices_from_path(path):
-    """List devicenames = get_devices_from_path(str path).
+    """Return device names from filenames in the given directory path.
 
     If path specified for devices/configs, then the list of filenames
     in dir will correspond to the list of devices.
@@ -175,7 +175,7 @@ def get_devices_from_path(path):
 
 
 def get_list_from_file(path):
-    """List text = get_list_from_file(str path).
+    """Read newline-separated items from a file and return as a list.
 
     Specified file (path) will contain a list of newline-separated items. This
     function is used for loading both configs/cmds as well as devices.
@@ -189,7 +189,7 @@ def get_list_from_file(path):
 
 
 def get_devices_from_opts(opts):
-    """List devicenames = get_devices_from_opts(dict opts).
+    """Return device names from command-line options.
 
     User specified on cmdline either a path to a file containing a list of
     devices or an actual list. Return the list!
@@ -213,7 +213,7 @@ def get_devices_from_opts(opts):
 
 
 def get_commands_from_opts(opts):
-    """List commands = get_commands_from_opts(dict opts).
+    """Return commands from command-line options.
 
     User specified on cmdline either a path to a file containing a list of
     commands/config or an actual list. Return the list!
@@ -235,11 +235,7 @@ def get_commands_from_opts(opts):
 
 
 def do_work(work=None, action_class=None):
-    """List results = do_work(list work)."""
-    """
-    Cycle through the list of jobs and then actually
-    load the config onto the devices.
-    """
+    """Cycle through the list of jobs and execute them on devices."""
     if work is None:
         work = []
     if DEBUG:
@@ -316,7 +312,7 @@ def print_work(work=None):
 
 
 def print_results(results=None):
-    """Binary success = print_results(list results)."""
+    """Print formatted results from completed jobs."""
     if results is None:
         results = []
     if DEBUG:
@@ -324,7 +320,7 @@ def print_results(results=None):
     for res in results:
         devname = res["devname"]
         data = res["data"]
-        print
+        print()
         print("###")
         print(f"# {devname}")
         print("###")

--- a/trigger/twister2.py
+++ b/trigger/twister2.py
@@ -337,7 +337,7 @@ class _TriggerCommandTransport(_CommandTransport):
 
 class _TriggerSessionTransport(_TriggerCommandTransport):
     def verifyHostKey(self, hostKey, fingerprint):
-        self.transport.getPeer().host
+        _ = self.transport.getPeer().host
 
         self._state = b"SECURING"
         return defer.succeed(1)

--- a/trigger/utils/network.py
+++ b/trigger/utils/network.py
@@ -55,7 +55,7 @@ def ping(host, count=1, timeout=5):
     return status == 0
 
 
-def test_tcp_port(host, port=23, timeout=5, check_result=False, expected_result=""):
+def test_tcp_port(host, port=23, timeout=5, check_result=False, expected_result=""):  # noqa: PT028
     """Attempts to connect to a TCP port. Returns a Boolean.
 
     If ``check_result`` is set, the first line of output is retreived from the
@@ -106,7 +106,7 @@ def test_tcp_port(host, port=23, timeout=5, check_result=False, expected_result=
             sock.close()
 
 
-def test_ssh(host, port=22, timeout=5, version=SSH_VERSION_STRINGS):
+def test_ssh(host, port=22, timeout=5, version=SSH_VERSION_STRINGS):  # noqa: PT028
     """Connect to a TCP port and confirm the SSH version. Defaults to SSHv2.
 
     Note that the default of ('SSH-1.99', 'SSH-2.0') both indicate SSHv2 per

--- a/trigger/utils/url.py
+++ b/trigger/utils/url.py
@@ -71,4 +71,4 @@ if __name__ == "__main__":
     for test in tests:
         print(test)
         pprint.pprint(parse_url(test))
-        print
+        print()


### PR DESCRIPTION
## Summary

Remove four rules from the global ruff ignore list with targeted fixes:

- **D104** (missing-package-docstring): add docstrings to `trigger/__init__.py` and `trigger/bin/__init__.py`
- **B018** (useless-expression): fix Python 2 bare `print` statements to `print()`, remove dead `unicode` compat shim, assign unused host lookup to `_` in `twister2.py`
- **PT028** (pytest-fixture-defaults): `# noqa` on `test_tcp_port` and `test_ssh` utility functions that aren't pytest tests
- **D402** (signature-in-docstring): rewrite 8 C-style signature docstrings in `docommand/core.py` to imperative descriptions

COM812 (trailing-comma-missing) was investigated but stays in the ignore list — it genuinely conflicts with the ruff formatter per ruff's own warning.

All rules now enforced project-wide. No behavioral or API changes. `refactor:` commit only — no release triggered.

## Test plan

- [x] `ruff check trigger/ tests/ configs/` passes clean
- [x] `ruff format --check trigger/ tests/ configs/` passes clean
- [x] All 170 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint- and docstring-focused refactor with tiny print/no-op changes; minimal behavioral impact aside from minor CLI output formatting.
> 
> **Overview**
> Updates ruff configuration to stop globally ignoring `D104`, `B018`, `PT028`, and `D402`, making these checks enforced project-wide.
> 
> Adds missing package docstrings (`trigger/__init__.py`, `trigger/bin/__init__.py`) and replaces Python 2-era patterns that triggered `B018` (bare `print` statements -> `print()`, simplifies `unicode` compatibility shim, assigns unused host lookup to `_` in `twister2.py`).
> 
> Rewrites legacy “C-style signature” docstrings in `trigger/contrib/docommand/core.py` to satisfy `D402`, and adds targeted `# noqa: PT028` to `test_tcp_port`/`test_ssh` in `trigger/utils/network.py` to avoid pytest-style false positives.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97b31e231a4467e6cd9f911155b940b3fab0c149. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->