### PR TITLE
refactor: enable ruff S606, E722, E741, B016, D404 lint rules

### DIFF
--- a/configs/bounce.py
+++ b/configs/bounce.py
@@ -1,4 +1,4 @@
-"""This file controls when bounce windows get auto-applied to network devices.
+"""Controls when bounce windows get auto-applied to network devices.
 
 This module is expected to provide a ``bounce()`` function that takes a
 `~trigger.netdevice.NetDevice` as the mandatory first argument and returns a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,16 +117,12 @@ ignore = [
     # --- Kept from v2.0.0 baseline ---
     "E402",     # module-import-not-at-top-of-file
     "E501",     # line-too-long (handled by formatter)
-    "E722",     # bare-except (intentional in many places)
-    "E741",     # ambiguous-variable-name (existing code style)
     "F401",     # unused-import (may be used dynamically)
     "F403",     # undefined-local-with-import-star
     "F405",     # undefined-local-with-import-star-usage
     "F821",     # undefined-name
     "UP031",    # printf-string-formatting
 
-    # --- Bugbear exceptions ---
-    "B016",     # raise-literal (used intentionally in tests)
     # --- Docstring exceptions (not enforcing coverage/style) ---
     "D100",     # undocumented-public-module
     "D101",     # undocumented-public-class
@@ -136,7 +132,6 @@ ignore = [
     "D107",     # undocumented-public-init
     "D205",     # missing-blank-line-after-summary
     "D401",     # non-imperative-mood
-    "D404",     # docstring-starts-with-this
 
     # --- Complexity (deep refactoring territory) ---
     "PLR0912",  # too-many-branches
@@ -148,7 +143,6 @@ ignore = [
     # --- Security false positives for network toolkit ---
     "S101",     # assert (used in tests)
     "S605",     # start-process-with-a-shell (fix manually)
-    "S606",     # start-process-with-no-shell
 
     # --- Other ---
     "RUF012",   # mutable-class-default (too many in device metadata)

--- a/trigger/acl/autoacl.py
+++ b/trigger/acl/autoacl.py
@@ -1,4 +1,4 @@
-"""This module controls when ACLs get auto-applied to network devices,
+"""Controls when ACLs get auto-applied to network devices,
 in addition to what is specified in acls.db.
 
 This is primarily used by :class:`~trigger.acl.db.AclsDB` to populate the

--- a/trigger/acl/dicts.py
+++ b/trigger/acl/dicts.py
@@ -1,4 +1,4 @@
-"""This code is originally from parser.py. It contains all the simple data definitions in
+"""Originally from parser.py. Contains all the simple data definitions in
 form of dictionaries and lists and such. This file is not meant to by used by itself.
 Imported into support.py.
 

--- a/trigger/acl/grammar.py
+++ b/trigger/acl/grammar.py
@@ -1,4 +1,4 @@
-"""This code is originally from parser.py. This is the basic grammar and rules
+"""Originally from parser.py. Provides the basic grammar and rules
 from which the other specific grammars are built. This file is not meant to by used by itself.
 Imported into the specific grammar files.
 

--- a/trigger/acl/ios.py
+++ b/trigger/acl/ios.py
@@ -1,5 +1,5 @@
-"""This code is originally from parser.py. This file is not meant to by used by itself.
-This is for IOS like ACLs.
+"""Originally from parser.py. Not meant to be used by itself.
+For IOS like ACLs.
 
 #Constants
     unary_port_operators

--- a/trigger/acl/junos.py
+++ b/trigger/acl/junos.py
@@ -1,5 +1,5 @@
-"""This code is originally from parser.py. This file is not meant to by used by itself.
-This is for JunOS like ACLs.
+"""Originally from parser.py. Not meant to be used by itself.
+For JunOS like ACLs.
 
 #Constants
     junos_match_types
@@ -55,19 +55,23 @@ class Policer:
                         if type == "bandwidth-limit":
                             limit = self.str2bits(value)
                             if limit > 32000000000 or limit < 32000:
-                                raise "bandwidth-limit must be between 32000bps and 32000000000bps"
+                                msg = "bandwidth-limit must be between 32000bps and 32000000000bps"
+                                raise ValueError(msg)
                             self.exceedings.append((type, limit))
                         elif type == "burst-size-limit":
                             limit = self.str2bits(value)
                             if limit > 100000000 or limit < 1500:
-                                raise "burst-size-limit must be between 1500B and 100,000,000B"
+                                msg = "burst-size-limit must be between 1500B and 100,000,000B"
+                                raise ValueError(msg)
                             self.exceedings.append((type, limit))
                         elif type == "bandwidth-percent":
                             limit = int(value)
                             if limit < 1 or limit > 100:
-                                raise "bandwidth-percent must be between 1 and 100"
+                                msg = "bandwidth-percent must be between 1 and 100"
+                                raise ValueError(msg)
                         else:
-                            raise f"Unknown policer if-exceeding tag: {type}"
+                            msg = f"Unknown policer if-exceeding tag: {type}"
+                            raise ValueError(msg)
                 elif k == "action":
                     for i in v:
                         self.actions.append(i)

--- a/trigger/acl/support.py
+++ b/trigger/acl/support.py
@@ -1,4 +1,4 @@
-"""This code is originally from parser.py. It consists of a lot of classes which
+"""Originally from parser.py. Consists of a lot of classes which
 support the various modules for parsing. This file is not meant to by used by itself.
 
 # Functions
@@ -278,26 +278,26 @@ class RangeList:
 
         return sorted(set(ret))
 
-    def _collapse(self, l):
+    def _collapse(self, items):
         """Reduce a sorted list of elements to ranges represented as tuples;
         e.g. [1, 2, 3, 4, 10] -> [(1, 4), 10].
         """
-        l = self._cleanup(l)  # Remove duplicates
+        items = self._cleanup(items)  # Remove duplicates
 
         # Don't bother reducing a single item
-        if len(l) <= 1:
-            return l
+        if len(items) <= 1:
+            return items
 
         # Make sure the elements are incrementable, or we can't reduce at all.
         try:
-            l[0] + 1
+            items[0] + 1
         except (TypeError, AttributeError):
-            return l
+            return items
         """
             try:
-                l[0][0] + 1
+                items[0][0] + 1
             except (TypeError, AttributeError):
-                return l
+                return items
         """
 
         # This last step uses a loop instead of pure functionalism because
@@ -306,30 +306,30 @@ class RangeList:
         # [x, x+1, ..., x+n] -> [(x, x+n)]
         n = 0
         try:
-            while l[n] + 1 == l[n + 1]:
+            while items[n] + 1 == items[n + 1]:
                 n += 1
         except IndexError:  # entire list collapses to one range
-            return [(l[0], l[-1])]
+            return [(items[0], items[-1])]
         if n == 0:
-            return [l[0], *self._collapse(l[1:])]
-        return [(l[0], l[n]), *self._collapse(l[n + 1 :])]
+            return [items[0], *self._collapse(items[1:])]
+        return [(items[0], items[n]), *self._collapse(items[n + 1 :])]
 
     def _do_collapse(self):
         self.data = self._collapse(self._expand(self.data))
 
-    def _expand(self, l):
+    def _expand(self, items):
         """Expand a list of elements and tuples back to discrete elements.
         Opposite of _collapse().
         """
-        if not l:
-            return l
+        if not items:
+            return items
         try:
             # Python 3: range() returns a range object, not a list
-            return list(range(l[0][0], l[0][1] + 1)) + self._expand(l[1:])
+            return list(range(items[0][0], items[0][1] + 1)) + self._expand(items[1:])
         except AttributeError:  # not incrementable
-            return l
+            return items
         except (TypeError, IndexError):
-            return [l[0], *self._expand(l[1:])]
+            return [items[0], *self._expand(items[1:])]
 
     def expanded(self):
         """Return a list with all ranges converted to discrete elements."""

--- a/trigger/acl/tools.py
+++ b/trigger/acl/tools.py
@@ -528,7 +528,7 @@ def worklog(title, diff, log_string="updated by express-gen"):
     rcs.checkin(log_string)
 
     # Use acl to insert into queue, should be replaced with API call
-    os.spawnlp(os.P_WAIT, "acl", "acl", "-i", title)
+    os.spawnlp(os.P_WAIT, "acl", "acl", "-i", title)  # noqa: S606
 
 
 # Classes
@@ -567,7 +567,8 @@ class ACLScript:
 
     def genargs(self, interactive=False):
         if not self.acl:
-            raise "need acl defined"
+            msg = "need acl defined"
+            raise ValueError(msg)
 
         argz = []
         argz.append(f"-a {self.acl}")
@@ -591,7 +592,8 @@ class ACLScript:
             argz.append("--replace-defined")
 
         else:
-            raise "invalid mode"
+            msg = "invalid mode"
+            raise ValueError(msg)
 
         for k, v in {
             "--source-address-from-file": self.source_ips,
@@ -619,7 +621,8 @@ class ACLScript:
 
         if len(self.modify_terms) and len(self.bcomments):
             print("Can only define either modify_terms or between comments")
-            raise "Can only define either modify_terms or between comments"
+            msg = "Can only define either modify_terms or between comments"
+            raise ValueError(msg)
 
         if self.modify_terms:
             argz.extend(f"-t {x}" for x in self.modify_terms)
@@ -650,18 +653,18 @@ class ACLScript:
 
     def errors_from_log(self, log):
         errors = ""
-        for l in log:
-            if "%%ERROR%%" in l:
-                l = l.spit("%%ERROR%%")[1]  # noqa: PLW2901
-                errors += l[1:] + "\n"
+        for line in log:
+            if "%%ERROR%%" in line:
+                line = line.spit("%%ERROR%%")[1]  # noqa: PLW2901
+                errors += line[1:] + "\n"
         return errors
 
     def diff_from_log(self, log):
         diff = ""
-        for l in log:
-            if "%%DIFF%%" in l:
-                l = l.split("%%DIFF%%")[1]  # noqa: PLW2901
-                diff += l[1:] + "\n"
+        for line in log:
+            if "%%DIFF%%" in line:
+                line = line.split("%%DIFF%%")[1]  # noqa: PLW2901
+                diff += line[1:] + "\n"
         return diff
 
     def set_acl(self, acl):

--- a/trigger/bin/acl_script.py
+++ b/trigger/bin/acl_script.py
@@ -525,8 +525,8 @@ def main():
 
         print(f'{prestr}"{acl_file}"')  # opts.acl)
         print(f"{prestr}BEGINNING OF CHANGES ===========")
-        for l in diff.split("\n"):
-            print(f"{prestr}{l}")
+        for line in diff.split("\n"):
+            print(f"{prestr}{line}")
         print(f"{prestr}END OF CHANGES =================")
 
         if not opts.no_input and not yesno("Do you want to save changes?"):

--- a/trigger/bin/load_acl.py
+++ b/trigger/bin/load_acl.py
@@ -772,7 +772,7 @@ def main():
         # catch failures to create a ticket
         try:
             cm_ticketnum = create_cm_ticket(work, oncall)
-        except:
+        except Exception:
             # create_cm_ticket is user defined
             # so we don't know what exceptions can be returned
             cm_ticketnum = None

--- a/trigger/changemgmt/bounce.py
+++ b/trigger/changemgmt/bounce.py
@@ -1,4 +1,4 @@
-"""This module controls how bounce windows get auto-applied to network devices.
+"""Controls how bounce windows get auto-applied to network devices.
 
 This is primarily used by `~trigger.changemgmt`.
 

--- a/trigger/cmds.py
+++ b/trigger/cmds.py
@@ -1,4 +1,4 @@
-"""This module abstracts the asynchronous execution of commands on multiple
+"""Abstracts the asynchronous execution of commands on multiple
 network devices. It allows for integrated parsing and event-handling of return
 data for rapid integration to existing or newly-created tools.
 
@@ -457,7 +457,7 @@ class Commando:
                         device,
                         self.map_parsed_results(command, fsm),
                     )
-                except:
+                except Exception:
                     log.msg(
                         "Unable to load TextFSM template, just updating with unstructured output",
                     )
@@ -641,7 +641,7 @@ class Commando:
     # Vendor-specific generate (to_)/parse (from_) methods
     # =======================================
     def to_juniper(self, device, commands=None, extra=None):
-        """This just creates a series of ``<command>foo</command>`` elements to
+        """Creates a series of ``<command>foo</command>`` elements to
         pass along to execute_junoscript().
         """
         commands = commands or self.commands
@@ -828,7 +828,7 @@ class NetACLInfo(Commando):
     # =======================================
 
     def to_cisco(self, dev, commands=None, extra=None):
-        """This is the "show me all interface information" command we pass to
+        """Generate the "show me all interface information" command we pass to
         IOS devices.
         """
         if dev.is_cisco_asa():
@@ -1117,7 +1117,9 @@ def _parse_ios_interfaces(
     # This is where the parsing is actually happening
     try:
         results = interfaces.parseString(data)
-    except:  # (ParseException, ParseFatalException, RecursiveGrammarException):
+    except (
+        Exception
+    ):  # (ParseException, ParseFatalException, RecursiveGrammarException)
         results = {}
 
     if auto_cleanup:

--- a/trigger/contrib/docommand/core.py
+++ b/trigger/contrib/docommand/core.py
@@ -347,7 +347,7 @@ def stage_tftp(acls, nonce):
             try:
                 copyfile(source, dest)
                 Path(dest).chmod(0o644)
-            except:
+            except OSError:
                 return None
     return True
 

--- a/trigger/contrib/xmlrpc/server.py
+++ b/trigger/contrib/xmlrpc/server.py
@@ -134,7 +134,7 @@ class TriggerXMLRPCServer(xmlrpc.XMLRPC):
                 module = importlib.import_module(mod_name, __name__)
             except NameError as msg:
                 log.msg(f"NameError: {msg}")
-            except:  # noqa: S110
+            except Exception:  # noqa: S110
                 pass
 
         if not module:

--- a/trigger/gorc.py
+++ b/trigger/gorc.py
@@ -1,4 +1,4 @@
-"""This is used by :doc:`../usage/scripts/go` to execute commands upon login to a
+"""Used by :doc:`../usage/scripts/go` to execute commands upon login to a
 device. A user may specify a list of commands to execute for each vendor. If
 the file is not found, or the syntax is bad, no commands will be passed to the
 device.

--- a/trigger/netdevices/__init__.py
+++ b/trigger/netdevices/__init__.py
@@ -478,7 +478,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
             oss = vendor_mapping[self.vendor]
             if self.operatingSystem.lower() in oss:
                 return f"{self.vendor}_{self.operatingSystem.lower()}"
-        except:
+        except (KeyError, AttributeError):
             log.msg("""Unable to find template for given device.
                     Check to see if your netdevices object has the 'platform' key.
                     Otherwise template does not exist.""")
@@ -976,7 +976,7 @@ class NetDevices(MutableMapping):
     _Singleton = None
 
     class _actual:
-        """This is the real class that stays active upon instantiation. All
+        """The real class that stays active upon instantiation. All
         attributes are inherited by NetDevices from this object. This means you
         do NOT reference ``_actual`` itself, and instead call the methods from
         the parent object.

--- a/trigger/netscreen.py
+++ b/trigger/netscreen.py
@@ -285,7 +285,8 @@ class NetScreen:
                     else:
                         found.append(self.service_book[entry])
                 else:
-                    raise "Unknown group type"
+                    msg = "Unknown group type"
+                    raise ValueError(msg)
 
             elif isinstance(node, NSRawPolicy):
                 policy_id = node.data.get("id", 0)
@@ -310,7 +311,8 @@ class NetScreen:
                             found = i
                             break
                     if not found:
-                        raise "Sub policy before policy defined"
+                        msg = "Sub policy before policy defined"
+                        raise ValueError(msg)
                 else:
                     # create a new policy
                     found = NSPolicy(id=policy_id, isglobal=isglobal, name=name)
@@ -413,12 +415,14 @@ class NSGroup(NetScreen):
     def add_address(self, addr):
         assert self.type == "address"
         if not isinstance(addr, NSAddress):
-            raise "add_address requires NSAddress object"
+            msg = "add_address requires NSAddress object"
+            raise TypeError(msg)
         # make sure the entry hasn't already been added, and
         # that all the zones are in the same zone
         for i in self.nodes:
             if i.zone != addr.zone:
-                raise f"zone {addr.zone} did not equal others in group"
+                msg = f"zone {addr.zone} did not equal others in group"
+                raise ValueError(msg)
             if i.name == addr.name:
                 return
         self.nodes.append(addr)
@@ -426,7 +430,8 @@ class NSGroup(NetScreen):
     def add_service(self, svc):
         assert self.type == "service"
         if not isinstance(svc, NSService):
-            raise "add_service requires NSService object"
+            msg = "add_service requires NSService object"
+            raise TypeError(msg)
         for i in self.nodes:
             if i.name == svc.name:
                 return
@@ -535,10 +540,11 @@ class NSServiceBook(NetScreen):
             return self.entries.append(item)
         if isinstance(item, NSGroup) and item.type == "service":
             return self.entries.append(item)
-        raise (
+        msg = (
             "item inserted into NSServiceBook, not an NSService or "
             "NSGroup.type='service' object"
         )
+        raise TypeError(msg)
 
     def output(self):
         ret = []
@@ -575,7 +581,8 @@ class NSAddressBook(NetScreen):
         if not isinstance(item, NSAddress) and (
             (not isinstance(item, NSGroup)) and item.type != "address"
         ):
-            raise "Item inserted int NSAddress not correct type"
+            msg = "Item inserted int NSAddress not correct type"
+            raise TypeError(msg)
 
         if not self.entries.has_key(item.zone):
             self.entries[item.zone] = []
@@ -705,7 +712,8 @@ class NSService(NetScreen):
             check_range(ports, 0, 65535)
             self.source_port = ports
         else:
-            raise "add_source_port needs int or tuple argument"
+            msg = "add_source_port needs int or tuple argument"
+            raise TypeError(msg)
 
     def set_destination_port(self, ports):
         if isinstance(ports, int):
@@ -715,7 +723,8 @@ class NSService(NetScreen):
             check_range(ports, 0, 65535)
             self.destination_port = ports
         else:
-            raise "add_destination_port needs int or tuple argument"
+            msg = "add_destination_port needs int or tuple argument"
+            raise TypeError(msg)
 
     def set_timeout(self, timeout):
         self.timeout = timeout
@@ -839,7 +848,8 @@ class NSPolicy(NetScreen):
     ):
         found = None
         if not protocol:
-            raise "no protocol defined in add_service"
+            msg = "no protocol defined in add_service"
+            raise ValueError(msg)
 
         if isinstance(destination_port, tuple):
             sname = "%s%d-%d" % (protocol, destination_port[0], destination_port[1])

--- a/trigger/twister.py
+++ b/trigger/twister.py
@@ -1262,7 +1262,7 @@ class TriggerSSHConnection(SSHConnection):
         self._channelOpener()
 
     def _channelOpener(self):
-        """This is what calls ``self.channelOpen()``."""
+        """Calls ``self.channelOpen()``."""
         # Default behavior: Single channel/conn
         self.openChannel(self.channel_class(conn=self))
 

--- a/trigger/twister2.py
+++ b/trigger/twister2.py
@@ -59,7 +59,7 @@ def generate_endpoint(device):
 
 
 class SSHSessionAddress:
-    """This object represents an endpoint's session details.
+    """Represents an endpoint's session details.
 
     This object would typically be loaded as follows:
 
@@ -79,7 +79,7 @@ class SSHSessionAddress:
 
 
 class _TriggerShellChannel(SSHChannel):
-    """This is the Trigger subclassed Channel object."""
+    """Trigger subclassed Channel object."""
 
     name = b"session"
 

--- a/trigger/utils/cli.py
+++ b/trigger/utils/cli.py
@@ -272,7 +272,7 @@ def update_password_and_reconnect(hostname):
                     args.append(sys.argv[idx])
                     break
             args.append(hostname)
-            os.execl(sys.executable, sys.executable, *args)
+            os.execl(sys.executable, sys.executable, *args)  # noqa: S606
 
 
 # Classes

--- a/trigger/utils/rcs.py
+++ b/trigger/utils/rcs.py
@@ -63,7 +63,7 @@ class RCS:
             try:
                 with Path(self.filename).open("w"):
                     pass
-            except:
+            except OSError:
                 return
             if not self.checkin(initial=True):
                 return

--- a/trigger/utils/templates.py
+++ b/trigger/utils/templates.py
@@ -56,7 +56,7 @@ def load_cmd_template(cmd, dev_type=None):
     try:
         with Path(get_template_path(cmd, dev_type=dev_type)).open("rb") as f:
             return textfsm.TextFSM(f)
-    except:
+    except Exception:
         log.msg(f"Unable to load template:\n{cmd} :: {dev_type}")
 
 
@@ -67,11 +67,11 @@ def get_textfsm_object(re_table, cli_output):
     rv = defaultdict(list)
     keys = re_table.header
     values = re_table.ParseText(cli_output)
-    l = []
+    pairs = []
     for item in values:
-        l.extend(zip(map(lambda x: x.lower(), keys), item, strict=False))
+        pairs.extend(zip(map(lambda x: x.lower(), keys), item, strict=False))
 
-    for k, v in l:
+    for k, v in pairs:
         rv[k].append(v)
 
     return dict(rv)


### PR DESCRIPTION
## Summary
- **S606** (2 fixes): Added `noqa` comments to intentional `os.spawnlp`/`os.execl` calls
- **E722** (8 fixes): Replaced bare `except:` with specific exception types (`Exception`, `OSError`, `KeyError`/`AttributeError`)
- **E741** (9 fixes): Renamed ambiguous variable `l` to descriptive names (`items`, `line`, `pairs`)
- **B016** (15 fixes): Converted `raise "string"` literals to proper `ValueError`/`TypeError` exceptions with EM101-compliant message variables
- **D404** (16 fixes): Reworded docstrings starting with "This" to use imperative/descriptive phrasing

Removes 5 rules from the global ignore list in `pyproject.toml` (34 → 29 ignored rules).

## Test plan
- [x] `ruff check trigger/ tests/ configs/` passes with zero violations
- [x] `ruff format --check trigger/ tests/ configs/` passes
- [x] `pytest` — 170 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily mechanical lint-driven edits (exception types/messages, variable renames, docstring tweaks) with minimal behavioral change, though narrower exception handling could slightly alter error paths.
> 
> **Overview**
> Updates `pyproject.toml` to stop globally ignoring Ruff rules `S606`, `E722`, `E741`, `B016`, and `D404`, effectively tightening lint enforcement.
> 
> Refactors various modules to comply: replaces bare `except:` blocks with specific exceptions, converts `raise "string"` literals into `ValueError`/`TypeError` with named message variables, renames ambiguous variables like `l` to clearer names (`items`, `line`, `pairs`), and rephrases docstrings that started with “This…”. Adds targeted `# noqa: S606` annotations for intentional process-spawning calls (`os.spawnlp`, `os.execl`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a72394443472b51d1a019f6543ef98d5178e5ada. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->