### PR TITLE
refactor: enable ruff D100, S605, F821, PLW0603, PLR0915 lint rules

### DIFF
--- a/configs/trigger_settings.py
+++ b/configs/trigger_settings.py
@@ -1,5 +1,8 @@
-# This is a sample settings.py that varies slightly from the default. Please see docs/configuration.rst or
-# trigger/conf/global_settings.py for the complete list of default settings.
+"""Sample Trigger settings that varies slightly from the default.
+
+Please see docs/configuration.rst or trigger/conf/global_settings.py for the
+complete list of default settings.
+"""
 
 import os
 import socket

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,11 +120,9 @@ ignore = [
     "F401",     # unused-import (may be used dynamically)
     "F403",     # undefined-local-with-import-star
     "F405",     # undefined-local-with-import-star-usage
-    "F821",     # undefined-name
     "UP031",    # printf-string-formatting
 
     # --- Docstring exceptions (not enforcing coverage/style) ---
-    "D100",     # undocumented-public-module
     "D101",     # undocumented-public-class
     "D102",     # undocumented-public-method
     "D103",     # undocumented-public-function
@@ -136,13 +134,10 @@ ignore = [
     # --- Complexity (deep refactoring territory) ---
     "PLR0912",  # too-many-branches
     "PLR0913",  # too-many-arguments
-    "PLR0915",  # too-many-statements
     "PLR2004",  # magic-value-comparison
-    "PLW0603",  # global-statement (parser pattern)
 
     # --- Security false positives for network toolkit ---
     "S101",     # assert (used in tests)
-    "S605",     # start-process-with-a-shell (fix manually)
 
     # --- Other ---
     "RUF012",   # mutable-class-default (too many in device metadata)

--- a/trigger/acl/junos.py
+++ b/trigger/acl/junos.py
@@ -116,7 +116,7 @@ class PolicerGroup:
     def __init__(self, format=None):
         self.policers = []
         self.format = format
-        global Comments
+        global Comments  # noqa: PLW0603
         self.comments = Comments
         Comments = []
 

--- a/trigger/acl/support.py
+++ b/trigger/acl/support.py
@@ -649,7 +649,7 @@ class ACL:
             self.terms = terms
         else:
             self.terms = TermList()
-        global Comments
+        global Comments  # noqa: PLW0603
         self.comments = Comments
         Comments = []
 
@@ -875,7 +875,7 @@ class Term:
         else:
             self.modifiers = modifiers
 
-        global Comments
+        global Comments  # noqa: PLW0603
         self.comments = Comments
         Comments = []
 
@@ -1147,7 +1147,7 @@ class Matches(MyDict):
     access checks.
     """
 
-    def __setitem__(self, key, arg):
+    def __setitem__(self, key, arg):  # noqa: PLR0915
         if key in (
             "ah-spi",
             "destination-mac-address",
@@ -1332,7 +1332,7 @@ class Matches(MyDict):
             a.append(s + ";")
         return a
 
-    def output_ios(self):
+    def output_ios(self):  # noqa: PLR0915
         """Return a string of IOS ACL bodies."""
         # This is a mess!  Thanks, Cisco.
         protos = []

--- a/trigger/acl/tools.py
+++ b/trigger/acl/tools.py
@@ -499,7 +499,7 @@ def write_tmpacl(acl, process_name="_tmpacl"):
 
 def diff_files(old, new):
     """Return a unified diff between two files."""
-    return os.popen(f"diff -Naur {old} {new}").read()
+    return os.popen(f"diff -Naur {old} {new}").read()  # noqa: S605
 
 
 def worklog(title, diff, log_string="updated by express-gen"):
@@ -641,9 +641,9 @@ class ACLScript:
         log = []
         # print self.cmd + ' ' + ' '.join(args)
         if interactive:
-            os.system(self.cmd + " " + " ".join(args))
+            os.system(self.cmd + " " + " ".join(args))  # noqa: S605
         else:
-            f = os.popen(self.cmd + " " + " ".join(args))
+            f = os.popen(self.cmd + " " + " ".join(args))  # noqa: S605
             line = f.readline()
             while line:
                 line = line.rstrip()

--- a/trigger/bin/acl.py
+++ b/trigger/bin/acl.py
@@ -125,7 +125,7 @@ def p_error(optp, msg=None):
     sys.exit(1)
 
 
-def main():
+def main():  # noqa: PLR0915
     """Main entry point for the CLI tool."""
     # Setup
     aclsdb = AclsDB()

--- a/trigger/bin/acl_script.py
+++ b/trigger/bin/acl_script.py
@@ -353,7 +353,7 @@ def log_term(term, msg="ADDING"):
     print()
 
 
-def wedge_acl(acl, new_term, between, opts):
+def wedge_acl(acl, new_term, between, opts):  # noqa: PLR0915
     if not between:
         # ugg, don't deal with this yet.
         return
@@ -459,7 +459,7 @@ def wedge_acl(acl, new_term, between, opts):
                 break
 
 
-def main():
+def main():  # noqa: PLR0915
     """Main entry point for the CLI tool."""
     opts, _args = parse_args(sys.argv)
     for acl_file in opts.acl:

--- a/trigger/bin/fe.py
+++ b/trigger/bin/fe.py
@@ -127,7 +127,7 @@ def edit(editfile):
     return os.popen("rcsdiff -u -b -q " + editfile).read()
 
 
-def main():
+def main():  # noqa: PLR0915
     """Main entry point for the CLI tool."""
     if len(sys.argv) < 2:
         print("usage: fe files...", file=sys.stderr)

--- a/trigger/bin/load_acl.py
+++ b/trigger/bin/load_acl.py
@@ -279,7 +279,7 @@ def debug_fakeout():
     return os.getenv("DEBUG_FAKEOUT") is not None
 
 
-def get_work(opts, args):
+def get_work(opts, args):  # noqa: PLR0915
     """Determine the set of devices to load on, and what ACLs to load on
     each.  Processes extra CLI arguments to modify the work queue. Return a
     dictionary of ``{nodeName: set(acls)}``.
@@ -551,7 +551,7 @@ def clear_load_queue(dev, acls):
     queue.complete(dev, acls)
 
 
-def activate(work, active, failures, jobs, redraw, opts):
+def activate(work, active, failures, jobs, redraw, opts):  # noqa: PLR0915
     """Refill the active work queue based on number of current active jobs.
 
     :param work:
@@ -689,7 +689,7 @@ def run(stdscr, work, jobs, failures, opts):
     reactor.run()
 
 
-def main():
+def main():  # noqa: PLR0915
     """The Main Event."""
     global opts
     opts, args = parse_args(sys.argv)
@@ -701,7 +701,7 @@ def main():
         opts.no_curses = True
         opts.queue = True
 
-    global queue
+    global queue  # noqa: PLW0603
     if opts.no_db:
         queue = None
 

--- a/trigger/bin/netdev.py
+++ b/trigger/bin/netdev.py
@@ -176,7 +176,7 @@ def parse_args(argv):
     return opts, args
 
 
-def search_builder(opts):
+def search_builder(opts):  # noqa: PLR0915
     """Builds a list comprehension from the options passed at command-line and
     then evaluates it to return a list of matching device names.
     """

--- a/trigger/bin/optimizer.py
+++ b/trigger/bin/optimizer.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 
 def sig_handler(s, d):
-    global stop_all
+    global stop_all  # noqa: PLW0603
     stop_all = True
 
 
@@ -260,7 +260,7 @@ chk_keys = ["protocol", "source-address", "destination-address", "destination-po
 rej_keys = ["reject", "deny", "discard"]
 
 
-def optimize_terms(terms, focused, which, opts):
+def optimize_terms(terms, focused, which, opts):  # noqa: PLR0915
     global stop_all  # noqa: PLW0602
     to_delete = dict()
     other = ""
@@ -518,7 +518,7 @@ def optimize(opts, terms, focused):
     return terms_unchunk(chunks)
 
 
-def do_work(opts, files):
+def do_work(opts, files):  # noqa: PLR0915
     global stop_all  # noqa: PLW0602
     for acl_file in files:
         focused = None

--- a/trigger/conf/global_settings.py
+++ b/trigger/conf/global_settings.py
@@ -1,6 +1,9 @@
-# Default Trigger settings. Override these with settings in the module
-# pointed-to by the TRIGGER_SETTINGS environment variable. This is pretty much
-# an exact duplication of how Django does this.
+"""Default Trigger settings.
+
+Override these with settings in the module pointed-to by the TRIGGER_SETTINGS
+environment variable. This is pretty much an exact duplication of how Django
+does this.
+"""
 
 import os
 import socket

--- a/trigger/contrib/commando/plugins/config_device.py
+++ b/trigger/contrib/commando/plugins/config_device.py
@@ -1,3 +1,5 @@
+"""Commando plugin for loading configuration onto Juniper devices."""
+
 import os.path
 import re
 import xml.etree.ElementTree as ET
@@ -116,9 +118,9 @@ class ConfigDevice(CommandoApplication):
         for fname in files:
             filecontents = ""
             if not Path(fname).is_file():
-                fname = tftp_dir + fname  # noqa: PLW2901
+                fname = self.tftp_dir + fname  # noqa: PLW2901
             try:
-                filecontents = file(fname).read()
+                filecontents = Path(fname).read_text()
             except OSError:
                 log.msg(f"Unable to open file: {fname}")
             if filecontents == "":

--- a/trigger/contrib/commando/plugins/show_clock.py
+++ b/trigger/contrib/commando/plugins/show_clock.py
@@ -1,3 +1,5 @@
+"""Commando plugin for retrieving clock information from network devices."""
+
 import contextlib
 import datetime
 import xml.etree.ElementTree as ET

--- a/trigger/contrib/commando/plugins/show_version.py
+++ b/trigger/contrib/commando/plugins/show_version.py
@@ -1,3 +1,5 @@
+"""Commando plugin for retrieving version information from network devices."""
+
 from twisted.python import log
 
 from trigger.contrib.commando import CommandoApplication

--- a/trigger/contrib/docommand/core.py
+++ b/trigger/contrib/docommand/core.py
@@ -334,10 +334,15 @@ def print_results(results=None):
     return True
 
 
-def stage_tftp(acls, nonce):
-    """Need to edit this for cmds, not just acls, but
-    the basic idea is borrowed from ``bin/load_acl``.
+def stage_tftp(devices, acl, nonce):
+    """Stage ACL files to TFTP root for device loading.
+
+    Borrowed from ``bin/load_acl``.
     """
+    from shutil import copyfile
+
+    from trigger.conf import settings
+
     for _device in devices:
         source = settings.FIREWALL_DIR + f"/acl.{acl}"
         dest = settings.TFTPROOT_DIR + f"/acl.{acl}.{nonce}"
@@ -491,6 +496,8 @@ def parse_args(argv, description=None):
         print("\n", err)
         sys.exit(1)
     if opts.quiet:
+        from trigger.utils.cli import NullDevice
+
         sys.stdout = NullDevice()
 
     # Mutate some global sentinel values based on opts
@@ -549,11 +556,11 @@ def verify_opts(opts):
 
 # TODO: There's gotta be a better way.
 def set_globals_from_opts(opts):
-    global DEBUG
-    global VERBOSE
-    global PUSH
-    global TIMEOUT
-    global FORCE_CLI
+    global DEBUG  # noqa: PLW0603
+    global VERBOSE  # noqa: PLW0603
+    global PUSH  # noqa: PLW0603
+    global TIMEOUT  # noqa: PLW0603
+    global FORCE_CLI  # noqa: PLW0603
     DEBUG = opts.debug
     VERBOSE = opts.verbose
     PUSH = opts.push

--- a/trigger/netdevices/loaders/mongodb.py
+++ b/trigger/netdevices/loaders/mongodb.py
@@ -1,3 +1,5 @@
+"""NetDevices loader for MongoDB-backed device metadata."""
+
 from trigger.exceptions import LoaderFailed
 from trigger.netdevices.loader import BaseLoader
 

--- a/trigger/netscreen.py
+++ b/trigger/netscreen.py
@@ -218,7 +218,7 @@ class NetScreen:
             return TIP(ipstr)
         return TIP(iptuple[0].strNormal())
 
-    def handle_raw_netscreen(self, rows):
+    def handle_raw_netscreen(self, rows):  # noqa: PLR0915
         """The parser will hand it's final output to this function, which decodes
         and puts everything in the right place.
         """

--- a/trigger/tacacsrc.py
+++ b/trigger/tacacsrc.py
@@ -391,7 +391,7 @@ class Tacacsrc:
             # Check for version
             if key == "version":
                 if val != self.version:
-                    msg = f"Bad .tacacsrc version ({v})"
+                    msg = f"Bad .tacacsrc version ({val})"
                     raise VersionMismatch(msg)
                 continue
 
@@ -499,7 +499,7 @@ class Tacacsrc:
     def _decrypt_and_read(self):
         """Decrypt file using GPG and return the raw data."""
         ret = []
-        for x in os.popen(f"gpg2 --no-tty --quiet -d {self.file_name}"):
+        for x in os.popen(f"gpg2 --no-tty --quiet -d {self.file_name}"):  # noqa: S605
             x = x.rstrip()  # noqa: PLW2901
             ret.append(x)
 
@@ -507,7 +507,7 @@ class Tacacsrc:
 
     def _encrypt_and_write(self):
         """Encrypt using GPG and dump password data to disk."""
-        fin, _fout = os.popen2(
+        fin, _fout = os.popen2(  # noqa: S605
             f"gpg2 --yes --quiet -r {self.username} -e -o {self.file_name}",
         )
         for line in self.rawdata:

--- a/trigger/twister.py
+++ b/trigger/twister.py
@@ -315,7 +315,7 @@ def handle_login_failure(failure):
     :param failure:
         A Twisted ``Failure`` instance
     """
-    global login_failed
+    global login_failed  # noqa: PLW0603
     login_failed = failure
 
 

--- a/trigger/utils/cli.py
+++ b/trigger/utils/cli.py
@@ -110,7 +110,7 @@ def get_terminal_width():
 
 def get_terminal_size():
     """Find and return stdouts terminal size as (height, width)."""
-    rows, cols = os.popen("stty size", "r").read().split()  # noqa: S607
+    rows, cols = os.popen("stty size", "r").read().split()  # noqa: S605, S607
     return rows, cols
 
 

--- a/trigger/utils/notifications/handlers.py
+++ b/trigger/utils/notifications/handlers.py
@@ -59,7 +59,7 @@ def _register_handlers():
 
     Any built-in event handlers need to be defined above this function.
     """
-    global HANDLERS_REGISTERED
+    global HANDLERS_REGISTERED  # noqa: PLW0603
     from trigger.conf import settings
 
     for handler_path in settings.NOTIFICATION_HANDLERS:
@@ -125,5 +125,5 @@ def notify(*args, **kwargs):
             continue
 
     # We don't want to get to this point
-    msg = f"No handlers succeeded for this event: {event}"
+    msg = f"No handlers succeeded for this event: {args}"
     raise RuntimeError(msg)

--- a/trigger/utils/rcs.py
+++ b/trigger/utils/rcs.py
@@ -83,7 +83,7 @@ class RCS:
             cmd = f'ci -m"first commit" -t- -i {self.filename}'
         else:
             cmd = f'ci -u -m"{logmsg}" {self.filename}'
-        status, output = commands.getstatusoutput(cmd)
+        status, output = commands.getstatusoutput(cmd)  # noqa: S605
 
         if verbose:
             print(output)
@@ -100,7 +100,7 @@ class RCS:
         True
         """
         cmd = f"co -f -l {self.filename}"
-        status, output = commands.getstatusoutput(cmd)
+        status, output = commands.getstatusoutput(cmd)  # noqa: S605
 
         if verbose:
             print(output)
@@ -120,7 +120,7 @@ class RCS:
         True
         """
         cmd = f"co -f -u {self.filename}"
-        status, output = commands.getstatusoutput(cmd)
+        status, output = commands.getstatusoutput(cmd)  # noqa: S605
 
         if verbose:
             print(output)
@@ -161,7 +161,7 @@ class RCS:
     def log(self):
         """Returns the RCS log as a string (see above)."""
         cmd = f"rlog {self.filename} 2>&1"
-        status, output = commands.getstatusoutput(cmd)
+        status, output = commands.getstatusoutput(cmd)  # noqa: S605
 
         if status > 0:
             return None


### PR DESCRIPTION
## Summary
- **D100** (6 fixes): Added module docstrings to undocumented public modules
- **S605** (10 fixes): Added `noqa` comments to intentional shell process calls (`os.popen`, `os.system`, `commands.getstatusoutput`)
- **F821** (11 fixes): Fixed real bugs — `self.tftp_dir` missing `self.` prefix, Python 2 `file()` → `Path.read_text()`, typo `v` → `val`, missing function params/imports in contrib code, undefined `event` → `args`
- **PLW0603** (12 fixes): Added `noqa` comments to intentional `global` statement usages (parser state, signal handlers, CLI tools)
- **PLR0915** (13 fixes): Added `noqa` comments to large functions in CLI tools and parsers

Removes 5 rules from the global ignore list in `pyproject.toml` (29 → 24 ignored rules).

## Test plan
- [x] `ruff check trigger/ tests/ configs/` passes with zero violations
- [x] `ruff format --check trigger/ tests/ configs/` passes
- [x] `pytest` — 170 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily lint/quality changes plus a few small bug fixes; behavior changes are limited to narrow utility/plugin paths and should be easy to validate.
> 
> **Overview**
> Updates Ruff configuration to stop globally ignoring `D100`, `S605`, `F821`, `PLW0603`, and `PLR0915`, and then brings the codebase into compliance.
> 
> Changes include adding missing module docstrings, annotating intentional `global` usage and large/complex functions with `# noqa`, and marking deliberate shell invocations (`os.popen`/`os.system`/`commands.getstatusoutput`) with `S605` suppressions.
> 
> Also fixes a handful of real runtime issues uncovered by the stricter linting (e.g., `file()` -> `Path.read_text()` in a Commando plugin, correcting a bad f-string variable in `Tacacsrc`, fixing `stage_tftp` signature/imports in `docommand`, and adjusting a notifications error message to reference the provided args).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e6fead43a679bd20c2a7631112ee92819cae396. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->