### PR TITLE
refactor: enable ruff D101, RUF012, F403, S101, PLR0912 lint rules

### DIFF
--- a/configs/autoacl.py
+++ b/configs/autoacl.py
@@ -30,7 +30,7 @@ log.msg("IN CUSTOM AUTOACL.PY FILE:", __file__)
 OWNERS = settings.VALID_OWNERS
 
 
-def autoacl(dev, explicit_acls=None):
+def autoacl(dev, explicit_acls=None):  # noqa: PLR0912
     """Given a NetDevice object, returns a set of **implicit** (auto) ACLs. We require
     a device object so that we don't have circular dependencies between netdevices
     and autoacl.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,12 +118,10 @@ ignore = [
     "E402",     # module-import-not-at-top-of-file
     "E501",     # line-too-long (handled by formatter)
     "F401",     # unused-import (may be used dynamically)
-    "F403",     # undefined-local-with-import-star
     "F405",     # undefined-local-with-import-star-usage
     "UP031",    # printf-string-formatting
 
     # --- Docstring exceptions (not enforcing coverage/style) ---
-    "D101",     # undocumented-public-class
     "D102",     # undocumented-public-method
     "D103",     # undocumented-public-function
     "D105",     # undocumented-magic-method
@@ -132,15 +130,10 @@ ignore = [
     "D401",     # non-imperative-mood
 
     # --- Complexity (deep refactoring territory) ---
-    "PLR0912",  # too-many-branches
     "PLR0913",  # too-many-arguments
     "PLR2004",  # magic-value-comparison
 
-    # --- Security false positives for network toolkit ---
-    "S101",     # assert (used in tests)
-
     # --- Other ---
-    "RUF012",   # mutable-class-default (too many in device metadata)
     "SLF001",   # private-member-access (common in Twisted patterns)
 ]
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -3,7 +3,7 @@ from io import StringIO
 
 from trigger.cmds import Commando
 from trigger.netdevices import NetDevices
-from trigger.utils.templates import *
+from trigger.utils.templates import *  # noqa: F403
 
 # Constants
 DEVICE_NAME = "test1-abc.net.aol.com"

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -11,7 +11,7 @@ __all__ = ["mock_redis"]
 
 # misc
 from . import misc
-from .misc import *
+from .misc import *  # noqa: F403
 
 __all__.extend(misc.__all__)
 

--- a/tests/utils/mock_redis.py
+++ b/tests/utils/mock_redis.py
@@ -11,6 +11,7 @@ __all__ = ("MockRedis", "Redis", "install")
 import re
 import sys
 from collections import defaultdict
+from typing import ClassVar
 
 
 class MockRedisLock:
@@ -72,7 +73,7 @@ class MockRedis:
     """
 
     # The 'Redis' store
-    redis = defaultdict(dict)
+    redis: ClassVar[dict] = defaultdict(dict)
 
     def __init__(self):
         """Initialize the object."""

--- a/trigger/acl/__init__.py
+++ b/trigger/acl/__init__.py
@@ -21,7 +21,7 @@ __all__ = ["acl_exists", "parser"]
 
 # Parser
 from . import parser
-from .parser import *
+from .parser import *  # noqa: F403
 
 __all__.extend(parser.__all__)
 

--- a/trigger/acl/grammar.py
+++ b/trigger/acl/grammar.py
@@ -18,7 +18,7 @@ __maintainer__ = "Jathan McCollum"
 __email__ = "jathanism@aol.com"
 __copyright__ = "Copyright 2006-2013, AOL Inc.; 2013 Saleforce.com"
 
-from .support import *
+from .support import *  # noqa: F403
 
 # Each production can be any of:
 # 1. string

--- a/trigger/acl/ios.py
+++ b/trigger/acl/ios.py
@@ -18,7 +18,7 @@ __maintainer__ = "Jathan McCollum"
 __email__ = "jathanism@aol.com"
 __copyright__ = "Copyright 2006-2013, AOL Inc.; 2013 Saleforce.com"
 
-from .grammar import *
+from .grammar import *  # noqa: F403
 
 
 class Remark(Comment):
@@ -37,7 +37,7 @@ class Remark(Comment):
 inverse_mask_table = dict([(make_inverse_mask(x), x) for x in range(33)])
 
 
-def handle_ios_match(a):
+def handle_ios_match(a):  # noqa: PLR0912
     protocol, source, dest = a[:3]
     extra = a[3:]
 
@@ -79,7 +79,7 @@ def handle_ios_match(a):
     return {"match": match, "modifiers": modifiers}
 
 
-def handle_ios_acl(rows):
+def handle_ios_acl(rows):  # noqa: PLR0912
     acl = ACL()
     for d in rows:
         if not d:

--- a/trigger/acl/junos.py
+++ b/trigger/acl/junos.py
@@ -28,7 +28,7 @@ __copyright__ = "Copyright 2006-2013, AOL Inc.; 2013 Saleforce.com"
 
 from trigger.conf import settings
 
-from .grammar import *
+from .grammar import *  # noqa: F403
 
 # Temporary resting place for comments, so the rest of the parser can
 # ignore them.  Yes, this makes the library not thread-safe.
@@ -40,7 +40,7 @@ class Policer:
     now, that just passes it through as a string.
     """
 
-    def __init__(self, name, data):
+    def __init__(self, name, data):  # noqa: PLR0912
         if not name:
             msg = "Policer requres name"
             raise exceptions.ActionError(msg)
@@ -136,6 +136,8 @@ class PolicerGroup:
 
 
 class QuotedString(str):
+    """String subclass that wraps its value in double quotes."""
+
     def __str__(self):
         return '"' + self + '"'
 

--- a/trigger/acl/parser.py
+++ b/trigger/acl/parser.py
@@ -33,9 +33,9 @@ from simpleparse.parser import Parser
 
 from trigger import exceptions
 
-from .ios import *
-from .junos import *
-from .support import *
+from .ios import *  # noqa: F403
+from .junos import *  # noqa: F403
+from .support import *  # noqa: F403
 
 # Exports
 __all__ = (
@@ -77,7 +77,7 @@ Comments = []
 
 
 class ACLProcessor(DispatchProcessor):
-    pass
+    """SimpleParse dispatch processor for ACL grammar rules."""
 
 
 def default_processor(self, tag_info, buffer):
@@ -112,7 +112,7 @@ def make_nondefault_processor(action):
 grammar = []
 for production, rule in rules.items():
     if isinstance(rule, tuple):
-        assert len(rule) == 2
+        assert len(rule) == 2  # noqa: S101
         setattr(ACLProcessor, production, make_nondefault_processor(rule[1]))
         grammar.append(f"{production} := {rule[0]}")
     else:
@@ -123,6 +123,8 @@ grammar = "\n".join(grammar)
 
 
 class ACLParser(Parser):
+    """SimpleParse parser for ACL text."""
+
     def buildProcessor(self):
         return ACLProcessor()
 
@@ -150,7 +152,7 @@ def parse(input_data):
     success, children, nextchar = parser.parse(data)
 
     if success and nextchar == len(data):
-        assert len(children) == 1
+        assert len(children) == 1  # noqa: S101
         return children[0]
     line = data[:nextchar].count("\n") + 1
     column = len(data[data[nextchar].rfind("\n") : nextchar]) + 1

--- a/trigger/acl/support.py
+++ b/trigger/acl/support.py
@@ -34,12 +34,13 @@ __email__ = "jathanism@aol.com"
 __copyright__ = "Copyright 2006-2013, AOL Inc.; 2013 Saleforce.com"
 
 import contextlib
+from typing import ClassVar
 
 import IPy
 
 from trigger import exceptions
 
-from .dicts import *
+from .dicts import *  # noqa: F403
 
 # Python 2/3 compatibility
 unicode = str
@@ -680,7 +681,7 @@ class ACL:
         # Make sure we properly set 'family' so it's automatically used for
         # printing.
         if family is not None:
-            assert family in ("inet", "inet6")
+            assert family in ("inet", "inet6")  # noqa: S101
         else:
             family = self.family
 
@@ -1053,7 +1054,7 @@ class Protocol:
     Acts like an integer, but stringify into a name if possible.
     """
 
-    num2name = {
+    num2name: ClassVar[dict[int, str]] = {
         1: "icmp",
         2: "igmp",
         4: "ipip",
@@ -1071,7 +1072,7 @@ class Protocol:
         # 112: 'vrrp' # Breaks Cisco compatibility
     }
 
-    name2num = {v: k for k, v in num2name.items()}
+    name2num: ClassVar[dict[str, int]] = {v: k for k, v in num2name.items()}
     name2num["ahp"] = 51  # undocumented Cisco special name
 
     def __init__(self, arg):
@@ -1147,7 +1148,7 @@ class Matches(MyDict):
     access checks.
     """
 
-    def __setitem__(self, key, arg):  # noqa: PLR0915
+    def __setitem__(self, key, arg):  # noqa: PLR0912, PLR0915
         if key in (
             "ah-spi",
             "destination-mac-address",
@@ -1332,7 +1333,7 @@ class Matches(MyDict):
             a.append(s + ";")
         return a
 
-    def output_ios(self):  # noqa: PLR0915
+    def output_ios(self):  # noqa: PLR0912, PLR0915
         """Return a string of IOS ACL bodies."""
         # This is a mess!  Thanks, Cisco.
         protos = []

--- a/trigger/acl/tools.py
+++ b/trigger/acl/tools.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import IPy
 
-from trigger.acl.parser import *
+from trigger.acl.parser import *  # noqa: F403
 from trigger.conf import settings
 
 # Defaults
@@ -83,7 +83,7 @@ def create_trigger_term(
     return term
 
 
-def check_access(terms_to_check, new_term, quiet=True, format="junos", acl_name=None):
+def check_access(terms_to_check, new_term, quiet=True, format="junos", acl_name=None):  # noqa: PLR0912
     """Determine whether access is permitted by a given ACL (list of terms).
 
     Tests a new term against a list of terms. Return True if access in new term
@@ -225,7 +225,7 @@ def create_access(terms_to_check, new_term):
 
 
 # note, following code is -not currently used-
-def insert_term_into_acl(new_term, aclobj, debug=False):
+def insert_term_into_acl(new_term, aclobj, debug=False):  # noqa: PLR0912
     """Return a new ACL object with the new_term added in the proper place based
     on the aclobj. Intended to recursively append to an interim ACL object
     based on a list of Term objects.
@@ -565,7 +565,7 @@ class ACLScript:
         for file in self.tempfiles:
             Path(file).unlink()
 
-    def genargs(self, interactive=False):
+    def genargs(self, interactive=False):  # noqa: PLR0912
         if not self.acl:
             msg = "need acl defined"
             raise ValueError(msg)

--- a/trigger/bin/acl.py
+++ b/trigger/bin/acl.py
@@ -125,7 +125,7 @@ def p_error(optp, msg=None):
     sys.exit(1)
 
 
-def main():  # noqa: PLR0915
+def main():  # noqa: PLR0912, PLR0915
     """Main entry point for the CLI tool."""
     # Setup
     aclsdb = AclsDB()

--- a/trigger/bin/acl_script.py
+++ b/trigger/bin/acl_script.py
@@ -353,7 +353,7 @@ def log_term(term, msg="ADDING"):
     print()
 
 
-def wedge_acl(acl, new_term, between, opts):  # noqa: PLR0915
+def wedge_acl(acl, new_term, between, opts):  # noqa: PLR0912, PLR0915
     if not between:
         # ugg, don't deal with this yet.
         return
@@ -414,7 +414,7 @@ def wedge_acl(acl, new_term, between, opts):  # noqa: PLR0915
             acl.terms = create_term
     elif isinstance(between, str):
         # find a specific term to modify
-        assert acl.format == "junos"
+        assert acl.format == "junos"  # noqa: S101
         for term in acl.terms:
             if term.name == between:
                 if opts.replace_defined:
@@ -459,7 +459,7 @@ def wedge_acl(acl, new_term, between, opts):  # noqa: PLR0915
                 break
 
 
-def main():  # noqa: PLR0915
+def main():  # noqa: PLR0912, PLR0915
     """Main entry point for the CLI tool."""
     opts, _args = parse_args(sys.argv)
     for acl_file in opts.acl:

--- a/trigger/bin/aclconv.py
+++ b/trigger/bin/aclconv.py
@@ -18,7 +18,7 @@ formats = {
 }
 
 
-def main():
+def main():  # noqa: PLR0912
     """Main entry point for the CLI tool."""
     optp = optparse.OptionParser(
         description="""\

--- a/trigger/bin/fe.py
+++ b/trigger/bin/fe.py
@@ -127,7 +127,7 @@ def edit(editfile):
     return os.popen("rcsdiff -u -b -q " + editfile).read()
 
 
-def main():  # noqa: PLR0915
+def main():  # noqa: PLR0912, PLR0915
     """Main entry point for the CLI tool."""
     if len(sys.argv) < 2:
         print("usage: fe files...", file=sys.stderr)

--- a/trigger/bin/load_acl.py
+++ b/trigger/bin/load_acl.py
@@ -279,7 +279,7 @@ def debug_fakeout():
     return os.getenv("DEBUG_FAKEOUT") is not None
 
 
-def get_work(opts, args):  # noqa: PLR0915
+def get_work(opts, args):  # noqa: PLR0912, PLR0915
     """Determine the set of devices to load on, and what ACLs to load on
     each.  Processes extra CLI arguments to modify the work queue. Return a
     dictionary of ``{nodeName: set(acls)}``.
@@ -689,7 +689,7 @@ def run(stdscr, work, jobs, failures, opts):
     reactor.run()
 
 
-def main():  # noqa: PLR0915
+def main():  # noqa: PLR0912, PLR0915
     """The Main Event."""
     global opts
     opts, args = parse_args(sys.argv)

--- a/trigger/bin/netdev.py
+++ b/trigger/bin/netdev.py
@@ -176,7 +176,7 @@ def parse_args(argv):
     return opts, args
 
 
-def search_builder(opts):  # noqa: PLR0915
+def search_builder(opts):  # noqa: PLR0912, PLR0915
     """Builds a list comprehension from the options passed at command-line and
     then evaluates it to return a list of matching device names.
     """

--- a/trigger/bin/optimizer.py
+++ b/trigger/bin/optimizer.py
@@ -130,6 +130,8 @@ is set to 0 (or off).
 
 
 class ProgressMeter:
+    """Display progress during ACL optimization."""
+
     def __init__(self, **kw):
         # What time do we start tracking our progress from?
         self.timestamp = kw.get("timestamp", time.time())
@@ -211,7 +213,7 @@ class ProgressMeter:
         self.last_refresh = time.time()
 
 
-def focus_terms(pcount, terms):
+def focus_terms(pcount, terms):  # noqa: PLR0912
     """Generates a list of term names that have a port count
     greater than pcount for the optimizer to 'focus' in on.
     """
@@ -260,7 +262,7 @@ chk_keys = ["protocol", "source-address", "destination-address", "destination-po
 rej_keys = ["reject", "deny", "discard"]
 
 
-def optimize_terms(terms, focused, which, opts):  # noqa: PLR0915
+def optimize_terms(terms, focused, which, opts):  # noqa: PLR0912, PLR0915
     global stop_all  # noqa: PLW0602
     to_delete = dict()
     other = ""
@@ -518,7 +520,7 @@ def optimize(opts, terms, focused):
     return terms_unchunk(chunks)
 
 
-def do_work(opts, files):  # noqa: PLR0915
+def do_work(opts, files):  # noqa: PLR0912, PLR0915
     global stop_all  # noqa: PLW0602
     for acl_file in files:
         focused = None

--- a/trigger/changemgmt/__init__.py
+++ b/trigger/changemgmt/__init__.py
@@ -7,6 +7,7 @@ __copyright__ = "Copyright 2006-2012, AOL Inc."
 
 # Imports
 from datetime import datetime, timedelta
+from typing import ClassVar
 
 from pytz import UTC, timezone
 
@@ -171,7 +172,7 @@ class BounceWindow:
     """
 
     # Prepopulate these objects to save a little horsepower
-    BOUNCE_STATUS = {n: BounceStatus(n) for n in BOUNCE_VALUES}
+    BOUNCE_STATUS: ClassVar[dict] = {n: BounceStatus(n) for n in BOUNCE_VALUES}
 
     def __init__(
         self,

--- a/trigger/cmds.py
+++ b/trigger/cmds.py
@@ -353,7 +353,7 @@ class Commando:
             "generate": "to_%s",
             "parse": "from_%s",
         }
-        assert method in METHOD_MAP
+        assert method in METHOD_MAP  # noqa: S101
 
         desired_method = None
 
@@ -907,7 +907,7 @@ class NetACLInfo(Commando):
     def __children_with_namespace(self, ns):
         return lambda elt, tag: elt.findall("./" + ns + tag)
 
-    def from_juniper(self, data, device, commands=None):
+    def from_juniper(self, data, device, commands=None):  # noqa: PLR0912
         """Do all the magic to parse Junos interfaces."""
         self.results[device.nodeName] = data  # "MY OWN JUNOS DATA"
 

--- a/trigger/conf/__init__.py
+++ b/trigger/conf/__init__.py
@@ -56,6 +56,8 @@ class BaseSettings:
 
 
 class Settings(BaseSettings):
+    """Trigger settings loaded from a settings module."""
+
     def __init__(self, settings_module):
         # Update this dict from global settings (but only for ALL_CAPS settings)
         for setting in dir(global_settings):

--- a/trigger/contrib/commando/plugins/config_device.py
+++ b/trigger/contrib/commando/plugins/config_device.py
@@ -27,6 +27,8 @@ def xmlrpc_config_device(*args, **kwargs):
 
 
 class ConfigDevice(CommandoApplication):
+    """Commando application for loading device configurations."""
+
     tftp_dir = settings.TFTPROOT_DIR
     tftp_host = settings.TFTP_HOST
     tftp_ip = gethostbyname(tftp_host)

--- a/trigger/contrib/commando/plugins/gather_info.py
+++ b/trigger/contrib/commando/plugins/gather_info.py
@@ -50,6 +50,7 @@ GatherInfo.results will look something like::
 """
 
 import re
+from typing import ClassVar
 
 from twisted.python import log
 
@@ -70,7 +71,7 @@ class GatherInfo(Commando):
     run per-platform.
     """
 
-    vendors = ["cisco"]
+    vendors: ClassVar[list[str]] = ["cisco"]
     ios_shver_parse = re.compile(
         r"""
         (?P<hostname>\S*)               (?# Capture Hostname)

--- a/trigger/contrib/commando/plugins/show_clock.py
+++ b/trigger/contrib/commando/plugins/show_clock.py
@@ -21,6 +21,8 @@ def xmlrpc_show_clock(*args, **kwargs):
 
 
 class ShowClock(CommandoApplication):
+    """Commando application for retrieving device clock information."""
+
     def to_cisco(self, dev, commands=None, extra=None):
         return ["show clock"]
 

--- a/trigger/contrib/commando/plugins/show_version.py
+++ b/trigger/contrib/commando/plugins/show_version.py
@@ -1,5 +1,7 @@
 """Commando plugin for retrieving version information from network devices."""
 
+from typing import ClassVar
+
 from twisted.python import log
 
 from trigger.contrib.commando import CommandoApplication
@@ -17,4 +19,4 @@ def xmlrpc_show_version(*args, **kwargs):
 class ShowVersion(CommandoApplication):
     """Simple example to run ``show version`` on devices."""
 
-    commands = ["show version"]
+    commands: ClassVar[list[str]] = ["show version"]

--- a/trigger/contrib/docommand/__init__.py
+++ b/trigger/contrib/docommand/__init__.py
@@ -19,6 +19,7 @@ import re
 import socket
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from typing import ClassVar
 from xml.etree.ElementTree import Element, ElementTree, SubElement
 
 from twisted.python import log
@@ -28,9 +29,8 @@ from trigger.conf import settings
 
 # Exports
 __all__ = ["CommandRunner", "ConfigLoader", "DoCommandBase", "core", "xml_print"]
-from core import *
-
 from . import core
+from .core import *  # noqa: F403
 
 __all__.extend(core.__all__)
 
@@ -190,14 +190,22 @@ class ConfigLoader(Commando):
     description = "Load configuration changes on network devices."
 
     # These are the only officially supported vendors at this time
-    vendors = ["a10", "arista", "brocade", "cisco", "foundry", "dell", "juniper"]
+    vendors: ClassVar[list[str]] = [
+        "a10",
+        "arista",
+        "brocade",
+        "cisco",
+        "foundry",
+        "dell",
+        "juniper",
+    ]
 
     # TODO: The config commands should be moved into NetDevice object
     # (.configure_commands). The save commands are already managed like that,
     # but we don't yet have a way to account for Juniper CLI commit command (it
     # assumes JunoScript). We need to not be hard-coding these types of things
     # all over the code-base.
-    known_commands = {
+    known_commands: ClassVar[dict] = {
         "config": {
             "a10": "configure terminal",
             "arista": "configure terminal",

--- a/trigger/netdevices/__init__.py
+++ b/trigger/netdevices/__init__.py
@@ -674,7 +674,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
         :param when:
             A datetime object.
         """
-        assert action == "load-acl"
+        assert action == "load-acl"  # noqa: S101
         return self.bounce.status(when) == changemgmt.BounceStatus("green")
 
     def next_ok(self, action, when=None):
@@ -687,7 +687,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
         :param when:
             A datetime object.
         """
-        assert action == "load-acl"
+        assert action == "load-acl"  # noqa: S101
         return self.bounce.next_ok(changemgmt.BounceStatus("green"), when)
 
     def is_router(self):
@@ -813,7 +813,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
             "pty": settings.SSH_PTY_DISABLED,
             "async": settings.SSH_ASYNC_DISABLED,
         }
-        assert method in METHOD_MAP
+        assert method in METHOD_MAP  # noqa: S101
         method_enabled = self._ssh_enabled(METHOD_MAP[method])
 
         return method_enabled and self.has_ssh()

--- a/trigger/netdevices/loader.py
+++ b/trigger/netdevices/loader.py
@@ -33,6 +33,8 @@ __all__ = ("BaseLoader", "load_metadata")
 
 # Classes
 class BaseLoader:
+    """Base class for NetDevices metadata loaders."""
+
     is_usable = False
 
     def __init__(self, *args, **kwargs):

--- a/trigger/netscreen.py
+++ b/trigger/netscreen.py
@@ -167,7 +167,7 @@ class NetScreen:
             rule,
         ) in rules.items():
             if isinstance(rule, tuple):
-                assert len(rule) == 2
+                assert len(rule) == 2  # noqa: S101
                 setattr(ACLProcessor, production, make_nondefault_processor(rule[1]))
                 self.grammar.append(f"{production} := {rule[0]}")
             else:
@@ -187,7 +187,7 @@ class NetScreen:
         success, children, nextchar = parser.parse(string)
 
         if success and nextchar == len(string):
-            assert len(children) == 1
+            assert len(children) == 1  # noqa: S101
             return children[0]
         line = string[:nextchar].count("\n") + 1
         column = len(string[string[nextchar].rfind("\n") : nextchar]) + 2
@@ -218,7 +218,7 @@ class NetScreen:
             return TIP(ipstr)
         return TIP(iptuple[0].strNormal())
 
-    def handle_raw_netscreen(self, rows):  # noqa: PLR0915
+    def handle_raw_netscreen(self, rows):  # noqa: PLR0912, PLR0915
         """The parser will hand it's final output to this function, which decodes
         and puts everything in the right place.
         """
@@ -413,7 +413,7 @@ class NSGroup(NetScreen):
         return getattr(self, "add_" + self.type)(item)
 
     def add_address(self, addr):
-        assert self.type == "address"
+        assert self.type == "address"  # noqa: S101
         if not isinstance(addr, NSAddress):
             msg = "add_address requires NSAddress object"
             raise TypeError(msg)
@@ -428,7 +428,7 @@ class NSGroup(NetScreen):
         self.nodes.append(addr)
 
     def add_service(self, svc):
-        assert self.type == "service"
+        assert self.type == "service"  # noqa: S101
         if not isinstance(svc, NSService):
             msg = "add_service requires NSService object"
             raise TypeError(msg)

--- a/trigger/tacacsrc.py
+++ b/trigger/tacacsrc.py
@@ -257,7 +257,7 @@ class Tacacsrc:
     system.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0912
         self,
         tacacsrc_file=None,
         use_gpg=settings.USE_GPG_AUTH,
@@ -359,7 +359,7 @@ class Tacacsrc:
 
         key += self._get_key_nonce_old()
         key = _perl_pack_Hstar_old((key + (" " * 48))[:48])
-        assert len(key) == 24
+        assert len(key) == 24  # noqa: S101
 
         return key
 
@@ -557,7 +557,7 @@ class Tacacsrc:
                         raise VersionMismatch(msg)
                 else:
                     realm, s, _junk = k.split("_")
-                    assert (realm, s) not in data
+                    assert (realm, s) not in data  # noqa: S101
                     data[(realm, s)] = v
 
         for (realm, k), v in data.items():

--- a/trigger/twister.py
+++ b/trigger/twister.py
@@ -613,7 +613,7 @@ def execute_junoscript(
     Please see `~trigger.twister.execute` for a full description of the
     arguments and how this works.
     """
-    assert device.vendor == "juniper"
+    assert device.vendor == "juniper"  # noqa: S101
 
     channel_class = TriggerSSHJunoscriptChannel
     prompt_pattern = ""
@@ -702,7 +702,7 @@ def execute_ioslike_telnet(
     Please see `~trigger.twister.execute` for a full description of the
     arguments and how this works.
     """
-    assert device.is_ioslike()
+    assert device.is_ioslike()  # noqa: S101
 
     d = defer.Deferred()
     action = IoslikeSendExpect(
@@ -769,7 +769,7 @@ def execute_ioslike_ssh(
     Please see `~trigger.twister.execute` for a full description of the
     arguments and how this works.
     """
-    assert device.is_ioslike()
+    assert device.is_ioslike()  # noqa: S101
 
     # Test if device requires shell + pty-req
     if device.requires_async_pty:
@@ -811,7 +811,7 @@ def execute_netscreen(
     Please see `~trigger.twister.execute` for a full description of the
     arguments and how this works.
     """
-    assert device.is_netscreen()
+    assert device.is_netscreen()  # noqa: S101
 
     # We live in a world where not every NetScreen device is local and can use
     # TACACS, so we must store unique credentials for each NetScreen device.
@@ -849,7 +849,7 @@ def execute_netscaler(
     Please see `~trigger.twister.execute` for a full description of the
     arguments and how this works.
     """
-    assert device.is_netscaler()
+    assert device.is_netscaler()  # noqa: S101
 
     channel_class = TriggerSSHNetscalerChannel
     method = "NetScaler"
@@ -882,7 +882,7 @@ def execute_pica8(
     Please see `~trigger.twister.execute` for a full description of the
     arguments and how this works.
     """
-    assert device.is_pica8()
+    assert device.is_pica8()  # noqa: S101
 
     channel_class = TriggerSSHPica8Channel
     method = "Async PTY"
@@ -1821,6 +1821,8 @@ PICA8_NO_MORE_COMMANDS = ["show"]
 
 
 class TriggerSSHPica8Channel(TriggerSSHAsyncPtyChannel):
+    """SSH channel for Pica8 devices."""
+
     def _setup_commanditer(self, commands=None):
         """Munge our list of commands and overload self.commanditer to append
         " | no-more" to any "show" commands.

--- a/trigger/utils/notifications/__init__.py
+++ b/trigger/utils/notifications/__init__.py
@@ -9,9 +9,8 @@ __copyright__ = "Copyright 2012-2012, AOL Inc."
 __all__ = []
 
 # Core
-from core import *
-
 from . import core
+from .core import *  # noqa: F403
 
 __all__.extend(core.__all__)
 
@@ -21,8 +20,7 @@ from . import events
 __all__.extend(events.__all__)
 
 # Handlers
-from handlers import *
-
 from . import handlers
+from .handlers import *  # noqa: F403
 
 __all__.extend(handlers.__all__)

--- a/trigger/utils/notifications/events.py
+++ b/trigger/utils/notifications/events.py
@@ -13,6 +13,8 @@ __maintainer__ = "Jathan McCollum"
 __email__ = "jathan.mccollum@teamaol.com"
 __copyright__ = "Copyright 2012-2012, AOL Inc."
 
+from typing import ClassVar
+
 from trigger.conf import settings
 
 # Exports
@@ -85,7 +87,7 @@ class Notification(Event):
     """
 
     required_args = ("title", "message")
-    status_map = {
+    status_map: ClassVar[dict] = {
         "success": settings.SUCCESS_RECIPIENTS,
         "failure": settings.FAILURE_RECIPIENTS,
     }
@@ -128,7 +130,7 @@ class EmailEvent(Notification):
     """An email notification event."""
 
     default_sender = settings.EMAIL_SENDER
-    status_map = {
+    status_map: ClassVar[dict] = {
         "success": settings.SUCCESS_EMAILS,
         "failure": settings.FAILURE_EMAILS,
     }

--- a/trigger/utils/xmltodict.py
+++ b/trigger/utils/xmltodict.py
@@ -33,7 +33,7 @@ __license__ = "MIT"
 
 
 class ParsingInterrupted(Exception):
-    pass
+    """Raised when XML parsing is interrupted by a callback."""
 
 
 class _DictSAXHandler:
@@ -204,7 +204,7 @@ def parse(xml_input, encoding="utf-8", *args, **kwargs):
     return handler.item
 
 
-def _emit(
+def _emit(  # noqa: PLR0912
     key,
     value,
     content_handler,


### PR DESCRIPTION
## Summary
- **D101**: Added docstrings to 10 undocumented public classes
- **RUF012**: Added `ClassVar` annotations to mutable class defaults across 7 files
- **F403**: Added `noqa: F403` to 14 wildcard imports; fixed 3 Python 2 style bare module imports (`from core import *` → `from .core import *`)
- **S101**: Added `noqa: S101` to 20 `assert` statements in non-test production code
- **PLR0912**: Added `noqa: PLR0912` to 24 functions with too-many-branches

Reduces globally ignored ruff rules from 24 to 19.

## Test plan
- [x] `ruff check trigger/ tests/ configs/` passes cleanly
- [x] `ruff format --check trigger/ tests/ configs/` passes cleanly
- [x] `pytest` — 170 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No functional behavior changes intended; updates are largely annotations, docstrings, and lint suppressions, with only minor import-path adjustments that could affect module resolution if mis-specified.
> 
> **Overview**
> Primarily a **lint-enablement refactor**: updates `pyproject.toml` to stop globally ignoring Ruff rules `D101`, `RUF012`, `F403`, `S101`, and `PLR0912`, and then adjusts code to comply.
> 
> Across the codebase this adds missing class docstrings (e.g. `ACLProcessor`, `ACLParser`, `ProgressMeter`, plugin apps), annotates mutable class attributes with `typing.ClassVar`, converts a few legacy absolute wildcard imports to explicit relative imports, and adds targeted `# noqa` suppressions for wildcard exports, `assert` usage, and high-branch-count functions (including in several CLI entrypoints and ACL parsing modules).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f90de09e1291759af7eb840662904b80a40c5576. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->