### PR TITLE
refactor: enable ruff D102, D105, D107, D205, D401, F405 lint rules

### DIFF
--- a/configs/autoacl.py
+++ b/configs/autoacl.py
@@ -11,7 +11,7 @@ and what ACLs will be applied to them.  You can save this output
 before editing and compare it to the output after your change.
 
 Skip down a bit to find the part you should edit.
-"""
+"""  # noqa: D205
 
 import sys
 
@@ -46,7 +46,7 @@ def autoacl(dev, explicit_acls=None):  # noqa: PLR0912
     <Vendor: Juniper>
     >>> autoacl(dev)
     set(['juniper-router-protect', 'juniper-router.policer'])
-    """
+    """  # noqa: D205
     # Explicitly pass a set of explicit_acls so that we can use it as a
     # dependency for assigning implicit_acls. Defaults to an empty set.
     if explicit_acls is None:
@@ -124,7 +124,7 @@ def autoacl(dev, explicit_acls=None):  # noqa: PLR0912
 
 
 def main():
-    """A simple syntax check and dump of all we see and know!"""
+    """A simple syntax check and dump of all we see and know!"""  # noqa: D401
     print("Syntax ok.")
     if len(sys.argv) > 1:
         from trigger.netdevices import NetDevices

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,20 +110,15 @@ select = [
     "UP",     # pyupgrade - Python 3 modernization
     "W",      # pycodestyle warnings
 ]
+extend-select = [
+    "D401",   # non-imperative-mood (not in google convention, enabled explicitly)
+]
 ignore = [
     # --- Formatter conflicts ---
     "COM812",   # trailing-comma-missing (handled by ruff formatter)
 
     # --- Kept from v2.0.0 baseline ---
     "E501",     # line-too-long (handled by formatter)
-    "F405",     # undefined-local-with-import-star-usage
-
-    # --- Docstring exceptions (not enforcing coverage/style) ---
-    "D102",     # undocumented-public-method
-    "D105",     # undocumented-magic-method
-    "D107",     # undocumented-public-init
-    "D205",     # missing-blank-line-after-summary
-    "D401",     # non-imperative-mood
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -112,12 +112,12 @@ class CheckTemplates(unittest.TestCase):
 
     def testTemplatePath(self):
         """Test that template path is correct."""
-        t_path = get_template_path("show clock", dev_type="cisco_ios")
+        t_path = get_template_path("show clock", dev_type="cisco_ios")  # noqa: F405
         self.assertTrue("vendor/ntc_templates/cisco_ios_show_clock.template" in t_path)
 
     def testGetTextFsmObject(self):
         """Test that we get structured data back from cli output."""
-        data = get_textfsm_object(self.re_table, cli_data)
+        data = get_textfsm_object(self.re_table, cli_data)  # noqa: F405
         self.assertTrue(isinstance(data, dict))
         keys = ["dayweek", "time", "timezone", "year", "day", "month"]
         # Python 3: dict.has_key() removed, use 'in' operator

--- a/trigger/acl/autoacl.py
+++ b/trigger/acl/autoacl.py
@@ -14,7 +14,7 @@ devices out of the Trigger packaging.
 
 If you do not specify a location for ``AUTOACL_FILE`` or the module cannot be
 loaded, then a default :func:`autoacl()` function ill be used.
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum, Eileen Tschetter"
 __maintainer__ = "Jathan McCollum"
@@ -64,5 +64,5 @@ except ImportError:
 
         NOTE: If the default function is returned it does nothing with the
         arguments and always returns an empty set.
-        """
+        """  # noqa: D205
         return set()

--- a/trigger/acl/db.py
+++ b/trigger/acl/db.py
@@ -16,7 +16,7 @@ set(['juniper-router.policer', 'juniper-router-protect'])
 {'all': set(['abc123', 'juniper-router-protect', 'juniper-router.policer']),
  'explicit': set(['abc123']),
   'implicit': set(['juniper-router-protect', 'juniper-router.policer'])}
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum"
 __maintainer__ = "Jathan McCollum"
@@ -63,7 +63,7 @@ class AclsDB:
     add/remove operations are for explicit associations only.
     """
 
-    def __init__(self):
+    def __init__(self):  # noqa: D107
         self.redis = r
         log.msg("ACLs database client initialized")
 
@@ -111,7 +111,7 @@ class AclsDB:
         'testgreenj', 'testops_blockmj']),
         'explicit': set(['test-bluej', 'testgreenj', 'testops_blockmj']),
         'implicit': set(['115j', 'protectRE', 'protectRE.policer'])}
-        """
+        """  # noqa: D401, D205
         acls = {}
 
         # Explicit (we want to make sure the key exists before we try to assign
@@ -142,7 +142,7 @@ class AclsDB:
         set(['testops_blockmj', 'test-bluej', 'testgreenj'])
         >>> a.get_acl_set(dev, 'implicit')
         set(['protectRE', 'protectRE.policer', '115j'])
-        """
+        """  # noqa: D205
         acls_dict = self.get_acl_dict(device)
         ACL_SETS = acls_dict.keys()
         if DEBUG:
@@ -180,7 +180,7 @@ def populate_explicit_acls(aclsdb_file):
 
 
 def backup_explicit_acls():
-    """Dumps acls:explicit:* to csv."""
+    """Dumps acls:explicit:* to csv."""  # noqa: D401
     import csv
 
     out = csv.writer(Path(ACLSDB_BACKUP).open("w"))  # noqa: SIM115
@@ -212,7 +212,7 @@ def get_all_acls(nd=None):
     >>> all_acls = get_all_acls()
     >>> all_acls['abc123']
     set([<NetDevice: test1-abc.net.aol.com>, <NetDevice: fw1-xyz.net.aol.com>])
-    """
+    """  # noqa: D401, D205
     nd = nd or get_netdevices()
     all_acls = defaultdict(set)
     for device in nd.all():
@@ -224,7 +224,7 @@ def get_all_acls(nd=None):
 def get_bulk_acls(nd=None):
     """Returns a set of acls with an applied count over
     settings.AUTOLOAD_BULK_THRESH.
-    """
+    """  # noqa: D401, D205
     nd = nd or get_netdevices()
     all_acls = get_all_acls()
     return set(
@@ -269,7 +269,7 @@ def get_matching_acls(wanted, exact=True, match_acl=True, match_device=False, nd
     >>> adb.get_matching_acls(['test1-abc'], match_device=True, exact=False)
     [('test1-abc.net.aol.com', ['abc123', 'juniper-router-protect',
     'juniper-router.policer'])]
-    """
+    """  # noqa: D205
     found = []
     wanted_set = set(wanted)
 

--- a/trigger/acl/dicts.py
+++ b/trigger/acl/dicts.py
@@ -21,7 +21,7 @@ Variables defined:
   tcp_flag_names
   tcp_flag_specials
   tcp_flag_rev
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum, Mike Biancaniello, Michael Harding, Michael Shields"
 __editor__ = "Joseph Malone"

--- a/trigger/acl/grammar.py
+++ b/trigger/acl/grammar.py
@@ -10,7 +10,7 @@ Imported into the specific grammar files.
     literals
     update
     dict_sum
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum, Mike Biancaniello, Michael Harding, Michael Shields"
 __editor__ = "Joseph Malone"
@@ -37,7 +37,7 @@ def S(prod):
     performing modifiers.
 
     :param prod: The parser product.
-    """
+    """  # noqa: D205
     subtagged.add(prod)
     return prod
 
@@ -57,7 +57,7 @@ def update(d, **kwargs):  # noqa: D103
     for key in kwargs:
         if key in d:
             msg = f"duplicate {key}"
-            raise exceptions.ParseError(msg)
+            raise exceptions.ParseError(msg)  # noqa: F405
     d.update(kwargs)
     return d
 
@@ -92,20 +92,20 @@ rules = {
     "anychar": "[ a-zA-Z0-9.$:()&,/'_-]",
     "hex": "[0-9a-fA-F]+",
     "ipchars": "[0-9a-fA-F:.]+",
-    "ipv4": ('digits, (".", digits)*', TIP),
-    "ipaddr": ("ipchars", TIP),
+    "ipv4": ('digits, (".", digits)*', TIP),  # noqa: F405
+    "ipaddr": ("ipchars", TIP),  # noqa: F405
     "cidr": (
         '("inactive:", ws+)?, (ipaddr / ipv4), "/", digits, (ws+, "except")?',
-        TIP,
+        TIP,  # noqa: F405
     ),
     "macaddr": 'hex, (":", hex)+',
-    "protocol": (literals(Protocol.name2num) + " / digits", do_protocol_lookup),
-    "tcp": ('"tcp" / "6"', Protocol("tcp")),
-    "udp": ('"udp" / "17"', Protocol("udp")),
-    "icmp": ('"icmp" / "1"', Protocol("icmp")),
-    "icmp_type": (literals(icmp_types) + " / digits", do_icmp_type_lookup),
-    "icmp_code": (literals(icmp_codes) + " / digits", do_icmp_code_lookup),
-    "port": (literals(ports) + " / digits", do_port_lookup),
-    "dscp": (literals(dscp_names) + " / digits", do_dscp_lookup),
+    "protocol": (literals(Protocol.name2num) + " / digits", do_protocol_lookup),  # noqa: F405
+    "tcp": ('"tcp" / "6"', Protocol("tcp")),  # noqa: F405
+    "udp": ('"udp" / "17"', Protocol("udp")),  # noqa: F405
+    "icmp": ('"icmp" / "1"', Protocol("icmp")),  # noqa: F405
+    "icmp_type": (literals(icmp_types) + " / digits", do_icmp_type_lookup),  # noqa: F405
+    "icmp_code": (literals(icmp_codes) + " / digits", do_icmp_code_lookup),  # noqa: F405
+    "port": (literals(ports) + " / digits", do_port_lookup),  # noqa: F405
+    "dscp": (literals(dscp_names) + " / digits", do_dscp_lookup),  # noqa: F405
     "root": "ws?, junos_raw_acl / junos_replace_family_acl / junos_replace_acl / junos_replace_policers / ios_acl, ws?",
 }

--- a/trigger/acl/ios.py
+++ b/trigger/acl/ios.py
@@ -9,7 +9,7 @@ For IOS like ACLs.
 # Functions
     'handle_ios_match',
     'handle_ios_acl',
-"""
+"""  # noqa: D205
 
 # Copied metadata from parser.py
 __author__ = "Jathan McCollum, Mike Biancaniello, Michael Harding, Michael Shields"
@@ -21,10 +21,10 @@ __copyright__ = "Copyright 2006-2013, AOL Inc.; 2013 Saleforce.com"
 from .grammar import *  # noqa: F403
 
 
-class Remark(Comment):
+class Remark(Comment):  # noqa: F405
     """IOS extended ACL "remark" lines automatically become comments when
     converting to other formats of ACL.
-    """
+    """  # noqa: D205
 
     def output_ios_named(self):
         """Output the Remark to IOS named format."""
@@ -34,15 +34,15 @@ class Remark(Comment):
 # Build a table to unwind Cisco's weird inverse netmask.
 # TODO (jathan): These don't actually get sorted properly, but it doesn't seem
 # to have mattered up until now. Worth looking into it at some point, though.
-inverse_mask_table = dict([(make_inverse_mask(x), x) for x in range(33)])
+inverse_mask_table = dict([(make_inverse_mask(x), x) for x in range(33)])  # noqa: F405
 
 
 def handle_ios_match(a):  # noqa: D103, PLR0912
     protocol, source, dest = a[:3]
     extra = a[3:]
 
-    match = Matches()
-    modifiers = Modifiers()
+    match = Matches()  # noqa: F405
+    modifiers = Modifiers()  # noqa: F405
 
     if protocol:
         match["protocol"] = [protocol]
@@ -70,7 +70,7 @@ def handle_ios_match(a):  # noqa: D103, PLR0912
             match["icmp-code"] = [extra[1]]
     elif protocol == "tcp":
         if extra == ["established"]:
-            match["tcp-flags"] = [tcp_flag_specials["tcp-established"]]
+            match["tcp-flags"] = [tcp_flag_specials["tcp-established"]]  # noqa: F405
         elif extra:
             raise NotImplementedError(extra)
     elif extra:
@@ -80,18 +80,18 @@ def handle_ios_match(a):  # noqa: D103, PLR0912
 
 
 def handle_ios_acl(rows):  # noqa: D103, PLR0912
-    acl = ACL()
+    acl = ACL()  # noqa: F405
     for d in rows:
         if not d:
             continue
         for k, v in d.items():
             if k == "no":
-                acl = ACL()
+                acl = ACL()  # noqa: F405
             elif k == "name":
                 if acl.name:
                     if v != acl.name:
                         msg = f"Name '{v}' does not match ACL '{acl.name}'"
-                        raise exceptions.ACLNameError(
+                        raise exceptions.ACLNameError(  # noqa: F405
                             msg,
                         )
                 else:
@@ -124,64 +124,64 @@ unary_port_operators = {
     "neq": lambda x: [(0, x - 1), (x + 1, 65535)],
 }
 
-rules.update(
+rules.update(  # noqa: F405
     {
         "ios_ip": "kw_any / host_ipv4 / ios_masked_ipv4",
         "kw_any": ('"any"', None),
         "host_ipv4": '"host", ts, ipv4',
-        S("ios_masked_ipv4"): (
+        S("ios_masked_ipv4"): (  # noqa: F405
             "ipv4, ts, ipv4_inverse_mask",
             # Python 3: Explicit tuple unpacking for string formatting
-            lambda x: TIP("%s/%d" % (x[0], x[1])),  # noqa: UP031
+            lambda x: TIP("%s/%d" % (x[0], x[1])),  # noqa: UP031, F405
         ),
         "ipv4_inverse_mask": (
-            literals(inverse_mask_table),
-            lambda x: inverse_mask_table[TIP(x)],
+            literals(inverse_mask_table),  # noqa: F405
+            lambda x: inverse_mask_table[TIP(x)],  # noqa: F405
         ),
         "kw_ip": ('"ip"', None),
-        S("ios_match"): (
+        S("ios_match"): (  # noqa: F405
             "kw_ip / protocol, ts, ios_ip, ts, ios_ip, (ts, ios_log)?",
             handle_ios_match,
         ),
-        S("ios_tcp_port_match"): (
+        S("ios_tcp_port_match"): (  # noqa: F405
             "tcp, ts, ios_ip_port, ts, ios_ip_port, (ts, established)?, (ts, ios_log)?",
             handle_ios_match,
         ),
-        S("ios_udp_port_match"): (
+        S("ios_udp_port_match"): (  # noqa: F405
             "udp, ts, ios_ip_port, ts, ios_ip_port, (ts, ios_log)?",
             handle_ios_match,
         ),
-        S("ios_ip_port"): "ios_ip, (ts, unary_port / ios_range)?",
-        S("unary_port"): (
+        S("ios_ip_port"): "ios_ip, (ts, unary_port / ios_range)?",  # noqa: F405
+        S("unary_port"): (  # noqa: F405
             "unary_port_operator, ts, port",
             lambda x: unary_port_operators[x[0]](x[1]),
         ),
-        "unary_port_operator": literals(unary_port_operators),
-        S("ios_range"): ('"range", ts, port, ts, port', lambda xy: [(xy[0], xy[1])]),
+        "unary_port_operator": literals(unary_port_operators),  # noqa: F405
+        S("ios_range"): ('"range", ts, port, ts, port', lambda xy: [(xy[0], xy[1])]),  # noqa: F405
         "established": '"established"',
-        S("ios_icmp_match"): (
+        S("ios_icmp_match"): (  # noqa: F405
             "icmp, ts, ios_ip, ts, ios_ip, (ts, ios_log)?, "
             "(ts, ios_icmp_message / "
             " (icmp_type, (ts, icmp_code)?))?, (ts, ios_log)?",
             handle_ios_match,
         ),
         "ios_icmp_message": (
-            literals(ios_icmp_messages),
-            lambda x: ios_icmp_messages[x],
+            literals(ios_icmp_messages),  # noqa: F405
+            lambda x: ios_icmp_messages[x],  # noqa: F405
         ),
         "ios_action": '"permit" / "deny"',
         "ios_log": '"log-input" / "log"',
-        S("ios_action_match"): (
+        S("ios_action_match"): (  # noqa: F405
             "ios_action, ts, ios_tcp_port_match / "
             "ios_udp_port_match / ios_icmp_match / ios_match",
-            lambda x: {"term": Term(action=x[0], **x[1])},
+            lambda x: {"term": Term(action=x[0], **x[1])},  # noqa: F405
         ),
         "ios_acl_line": "ios_acl_match_line / ios_acl_no_line",
-        S("ios_acl_match_line"): (
+        S("ios_acl_match_line"): (  # noqa: F405
             '"access-list", ts, digits, ts, ios_action_match',
-            lambda x: update(x[1], name=x[0], format="ios"),
+            lambda x: update(x[1], name=x[0], format="ios"),  # noqa: F405
         ),
-        S("ios_acl_no_line"): (
+        S("ios_acl_no_line"): (  # noqa: F405
             '"no", ts, "access-list", ts, digits',
             lambda x: {"no": True, "name": x[0]},
         ),
@@ -190,32 +190,32 @@ rules.update(
             "ios_ext_no_line / ios_remark_line / "
             "ios_rebind_acl_line / ios_rebind_receive_acl_line"
         ),
-        S("ios_ext_name_line"): (
+        S("ios_ext_name_line"): (  # noqa: F405
             '"ip", ts, "access-list", ts, "extended", ts, word',
             lambda x: {"name": x[0], "format": "ios_named"},
         ),
-        S("ios_ext_no_line"): (
+        S("ios_ext_no_line"): (  # noqa: F405
             '"no", ts, "ip", ts, "access-list", ts, "extended", ts, word',
             lambda x: {"no": True, "name": x[0]},
         ),
         # Brocade "ip rebind-acl foo" or "ip rebind-receive-acl foo" syntax
-        S("ios_rebind_acl_line"): (
+        S("ios_rebind_acl_line"): (  # noqa: F405
             '"ip", ts, "rebind-acl", ts, word',
             lambda x: {"name": x[0], "format": "ios_brocade"},
         ),
         # Brocade "ip rebind-acl foo" or "ip rebind-receive-acl foo" syntax
-        S("ios_rebind_receive_acl_line"): (
+        S("ios_rebind_receive_acl_line"): (  # noqa: F405
             '"ip", ts, "rebind-receive-acl", ts, word',
             lambda x: {"name": x[0], "format": "ios_brocade", "receive_acl": True},
         ),
-        S("icomment"): ('"!", ts?, icomment_body', lambda x: x),
-        "icomment_body": ('-"\n"*', Comment),
-        S("ios_remark_line"): (
+        S("icomment"): ('"!", ts?, icomment_body', lambda x: x),  # noqa: F405
+        "icomment_body": ('-"\n"*', Comment),  # noqa: F405
+        S("ios_remark_line"): (  # noqa: F405
             '("access-list", ts, digits_s, ts)?, "remark", ts, remark_body',
             lambda x: x,
         ),
         "remark_body": ('-"\n"*', Remark),
         ">ios_line<": ('ts?, (ios_acl_line / ios_ext_line / "end")?, ts?, icomment?'),
-        S("ios_acl"): ('(ios_line, "\n")*, ios_line', handle_ios_acl),
+        S("ios_acl"): ('(ios_line, "\n")*, ios_line', handle_ios_acl),  # noqa: F405
     },
 )

--- a/trigger/acl/junos.py
+++ b/trigger/acl/junos.py
@@ -17,7 +17,7 @@ For JunOS like ACLs.
     handle_junos_policers
     handle_junos_term
     juniper_multiline_comments
-"""
+"""  # noqa: D205
 
 # Copied metadata from parser.py
 __author__ = "Jathan McCollum, Mike Biancaniello, Michael Harding, Michael Shields"
@@ -38,12 +38,12 @@ Comments = []
 class Policer:
     """Container class for policer policy definitions. This is a dummy class for
     now, that just passes it through as a string.
-    """
+    """  # noqa: D205
 
-    def __init__(self, name, data):  # noqa: PLR0912
+    def __init__(self, name, data):  # noqa: PLR0912, D107
         if not name:
             msg = "Policer requres name"
-            raise exceptions.ActionError(msg)
+            raise exceptions.ActionError(msg)  # noqa: F405
         self.name = name
         self.exceedings = []
         self.actions = []
@@ -76,7 +76,7 @@ class Policer:
                     for i in v:
                         self.actions.append(i)
 
-    def str2bits(self, str):
+    def str2bits(self, str):  # noqa: D102
         try:
             val = int(str)
         except Exception as err:
@@ -88,13 +88,13 @@ class Policer:
             raise ValueError(msg) from err
         return val
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"<{self.__class__.__name__}: {self.name!r}>"
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         return self.data
 
-    def output(self):
+    def output(self):  # noqa: D102
         output = [f"policer {self.name} {{"]
         if self.exceedings:
             output.append("    if-exceeding {")
@@ -113,19 +113,19 @@ class Policer:
 class PolicerGroup:
     """Container for Policer objects. Juniper only."""
 
-    def __init__(self, format=None):
+    def __init__(self, format=None):  # noqa: D107
         self.policers = []
         self.format = format
         global Comments  # noqa: PLW0603
         self.comments = Comments
         Comments = []
 
-    def output(self, format=None, *largs, **kwargs):
+    def output(self, format=None, *largs, **kwargs):  # noqa: D102
         if format is None:
             format = self.format
         return getattr(self, "output_" + format)(*largs, **kwargs)
 
-    def output_junos(self, replace=False):
+    def output_junos(self, replace=False):  # noqa: D102
         output = []
         for ent in self.policers:
             output.extend(ent.output())
@@ -138,7 +138,7 @@ class PolicerGroup:
 class QuotedString(str):
     """String subclass that wraps its value in double quotes."""
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         return '"' + self + '"'
 
 
@@ -146,8 +146,8 @@ junos_match_types = []
 
 
 def braced_list(arg):
-    """Returned braced output.  Will alert if comment is malformed."""
-    return '("{{", jws?, ({}, jws?)*, "}}"!{})'.format(arg, errs["comm_start"])
+    """Returned braced output.  Will alert if comment is malformed."""  # noqa: D401
+    return '("{{", jws?, ({}, jws?)*, "}}"!{})'.format(arg, errs["comm_start"])  # noqa: F405
 
 
 def keyword_match(keyword, arg=None):  # noqa: D103
@@ -155,14 +155,14 @@ def keyword_match(keyword, arg=None):  # noqa: D103
         prod = "junos_" + k.replace("-", "_")
         junos_match_types.append(prod)
         if arg is None:
-            rules[prod] = (f'"{k}", jsemi', {k: True})
+            rules[prod] = (f'"{k}", jsemi', {k: True})  # noqa: F405
         else:
             tokens = f'"{k}", jws, '
-            if k in address_matches:
+            if k in address_matches:  # noqa: F405
                 tokens += braced_list(arg + ", jsemi")
             else:
                 tokens += arg + ", jsemi"
-            rules[S(prod)] = (tokens, lambda x, k=k: {k: x})
+            rules[S(prod)] = (tokens, lambda x, k=k: {k: x})  # noqa: F405
 
 
 keyword_match("address", "cidr / ipaddr")
@@ -181,7 +181,7 @@ keyword_match("tcp-initial")
 
 
 def range_match(key, arg):  # noqa: D103
-    rules[S(arg + "_range")] = (f'{arg}, "-", {arg}', tuple)
+    rules[S(arg + "_range")] = (f'{arg}, "-", {arg}', tuple)  # noqa: F405
     match = f"{arg}_range / {arg}"
     keyword_match(key, f'{match} / ("[", jws?, ({match}, jws?)*, "]")')
 
@@ -214,13 +214,13 @@ def handle_junos_acl(x):
     parser.
 
     Don't forget to wrap your token in S()!
-    """
-    a = ACL(name=x[0], format="junos")
+    """  # noqa: D205
+    a = ACL(name=x[0], format="junos")  # noqa: F405
     for elt in x[1:]:
         # Handle dictionary args we throw at the constructor
         if isinstance(elt, dict):
             a.__dict__.update(elt)
-        elif isinstance(elt, Term):
+        elif isinstance(elt, Term):  # noqa: F405
             a.terms.append(elt)
         elif isinstance(elt, Policer):
             a.policers.append(elt)
@@ -238,7 +238,7 @@ def handle_junos_family_acl(x):
     parser.
 
     Don't forget to wrap your token in S()!
-    """
+    """  # noqa: D401, D205
     family, aclobj = x
     aclobj.family = family
     return aclobj
@@ -259,8 +259,8 @@ def handle_junos_policers(x):
 def handle_junos_term(d):
     """Parse a JUNOS term and return a Term object."""
     if "modifiers" in d:
-        d["modifiers"] = Modifiers(d["modifiers"])
-    return Term(**d)
+        d["modifiers"] = Modifiers(d["modifiers"])  # noqa: F405
+    return Term(**d)  # noqa: F405
 
 
 # For multiline comments
@@ -276,23 +276,23 @@ def juniper_multiline_comments():
     return single
 
 
-rules.update(
+rules.update(  # noqa: F405
     {
         "jword": "double_quoted / word",
         "double_quoted": ('"\\"", -[\\"]+, "\\""', lambda x: QuotedString(x[1:-1])),
         ">jws<": "(ws / jcomment)+",
-        S("jcomment"): ("jslashbang_comment", lambda x: Comment(x[0])),
+        S("jcomment"): ("jslashbang_comment", lambda x: Comment(x[0])),  # noqa: F405
         "<comment_start>": '"/*"',
         "<comment_stop>": '"*/"',
         ">jslashbang_comment<": "comment_start, jcomment_body, !{}, comment_stop".format(
-            errs["comm_stop"],
+            errs["comm_stop"],  # noqa: F405
         ),
         "jcomment_body": juniper_multiline_comments(),
         # Errors on missing ';', ignores multiple ;; and normalizes to one.
-        "<jsemi>": "jws?, [;]+!{}".format(errs["semicolon"]),
-        "fragment_flag": literals(fragment_flag_names),
-        "ip_option": "digits / " + literals(ip_option_names),
-        "tcp_flag": literals(tcp_flag_names),
+        "<jsemi>": "jws?, [;]+!{}".format(errs["semicolon"]),  # noqa: F405
+        "fragment_flag": literals(fragment_flag_names),  # noqa: F405
+        "ip_option": "digits / " + literals(ip_option_names),  # noqa: F405
+        "tcp_flag": literals(tcp_flag_names),  # noqa: F405
     },
 )
 
@@ -301,9 +301,9 @@ rules.update(
 # that config onto the router, the comments will not remain in place on
 # the next load of a similar config (e.g., another ACL).  I had a workaround
 # for this but it made the parser substantially slower.
-rules.update(
+rules.update(  # noqa: F405
     {
-        S("junos_raw_acl"): (
+        S("junos_raw_acl"): (  # noqa: F405
             'jws?, "filter", jws, jword, jws?, '
             + braced_list("junos_iface_specific / junos_term / junos_policer"),
             handle_junos_acl,
@@ -315,11 +315,11 @@ rules.update(
         "junos_replace_acl": (
             'jws?, "firewall", jws?, "{", jws?, "replace:", jws?, (junos_raw_acl, jws?)*, "}"'
         ),
-        S("junos_replace_family_acl"): (
+        S("junos_replace_family_acl"): (  # noqa: F405
             'jws?, "firewall", jws?, "{", jws?, junos_filter_family, jws?, "{", jws?, "replace:", jws?, (junos_raw_acl, jws?)*, "}", jws?, "}"',
             handle_junos_family_acl,
         ),
-        S("junos_replace_policers"): (
+        S("junos_replace_policers"): (  # noqa: F405
             '"firewall", jws?, "{", jws?, "replace:", jws?, (junos_policer, jws?)*, "}"',
             handle_junos_policers,
         ),
@@ -329,32 +329,32 @@ rules.update(
             '"{", jws?, (jword / "[" / "]" / ";" / opaque_braced_group / jws)*, "}"',
             lambda x: x,
         ),
-        S("junos_term"): (
+        S("junos_term"): (  # noqa: F405
             'maybe_inactive, "term", jws, junos_term_name, '
             "jws?, " + braced_list("junos_from / junos_then"),
-            lambda x: handle_junos_term(dict_sum(x)),
+            lambda x: handle_junos_term(dict_sum(x)),  # noqa: F405
         ),
-        S("junos_term_name"): ("jword", lambda x: {"name": x[0]}),
+        S("junos_term_name"): ("jword", lambda x: {"name": x[0]}),  # noqa: F405
         "maybe_inactive": ('("inactive:", jws)?', lambda x: {"inactive": len(x) > 0}),
-        S("junos_from"): (
+        S("junos_from"): (  # noqa: F405
             '"from", jws?, ' + braced_list("junos_match"),
-            lambda x: {"match": Matches(dict_sum(x))},
+            lambda x: {"match": Matches(dict_sum(x))},  # noqa: F405
         ),
-        S("junos_then"): ("junos_basic_then / junos_braced_then", dict_sum),
-        S("junos_braced_then"): (
+        S("junos_then"): ("junos_basic_then / junos_braced_then", dict_sum),  # noqa: F405
+        S("junos_braced_then"): (  # noqa: F405
             '"then", jws?, ' + braced_list("junos_action/junos_modifier, jsemi"),
-            dict_sum,
+            dict_sum,  # noqa: F405
         ),
-        S("junos_basic_then"): ('"then", jws?, junos_action, jsemi', dict_sum),
-        S("junos_policer"): (
+        S("junos_basic_then"): ('"then", jws?, junos_action, jsemi', dict_sum),  # noqa: F405
+        S("junos_policer"): (  # noqa: F405
             '"policer", jws, junos_term_name, jws?, '
             + braced_list("junos_exceeding / junos_policer_then"),
             lambda x: Policer(x[0]["name"], x[1:]),
         ),
-        S("junos_policer_then"): (
+        S("junos_policer_then"): (  # noqa: F405
             '"then", jws?, ' + braced_list("junos_policer_action, jsemi")
         ),
-        S("junos_policer_action"): (
+        S("junos_policer_action"): (  # noqa: F405
             'junos_discard / junos_fwd_class / ("loss-priority", jws, jword)',
             lambda x: {"action": x},
         ),
@@ -368,39 +368,39 @@ rules.update(
             lambda x: {"forwarding-class": x[0]},
         ),
         "junos_filter_specific": ('"filter-specific"'),
-        S("junos_exceeding"): (
+        S("junos_exceeding"): (  # noqa: F405
             '"if-exceeding", jws?, '
             + braced_list("junos_bw_limit/junos_bw_perc/junos_burst_limit"),
             lambda x: {"if-exceeding": x},
         ),
-        S("junos_bw_limit"): (
+        S("junos_bw_limit"): (  # noqa: F405
             '"bandwidth-limit", jws, word, jsemi',
             lambda x: ("bandwidth-limit", x[0]),
         ),
-        S("junos_bw_perc"): (
+        S("junos_bw_perc"): (  # noqa: F405
             '"bandwidth-percent", jws, alphanums, jsemi',
             lambda x: ("bandwidth-percent", x[0]),
         ),
-        S("junos_burst_limit"): (
+        S("junos_burst_limit"): (  # noqa: F405
             '"burst-size-limit", jws, alphanums, jsemi',
             lambda x: ("burst-size-limit", x[0]),
         ),
-        S("junos_match"): (" / ".join(junos_match_types), dict_sum),
-        S("junos_action"): (
+        S("junos_match"): (" / ".join(junos_match_types), dict_sum),  # noqa: F405
+        S("junos_action"): (  # noqa: F405
             "junos_one_action / junos_reject_action /"
             "junos_reject_action / junos_ri_action",
             lambda x: {"action": x[0]},
         ),
         "junos_one_action": ('"accept" / "discard" / "reject" / ("next", jws, "term")'),
         "junos_reject_action": (
-            '"reject", jws, ' + literals(icmp_reject_codes),
+            '"reject", jws, ' + literals(icmp_reject_codes),  # noqa: F405
             lambda x: ("reject", x),
         ),
-        S("junos_ri_action"): (
+        S("junos_ri_action"): (  # noqa: F405
             '"routing-instance", jws, jword',
             lambda x: ("routing-instance", x[0]),
         ),
-        S("junos_modifier"): (
+        S("junos_modifier"): (  # noqa: F405
             "junos_one_modifier / junos_arg_modifier",
             lambda x: {"modifiers": x},
         ),
@@ -408,7 +408,7 @@ rules.update(
             '"log" / "sample" / "syslog" / "port-mirror"',
             lambda x: (x, True),
         ),
-        S("junos_arg_modifier"): "junos_arg_modifier_kw, jws, jword",
+        S("junos_arg_modifier"): "junos_arg_modifier_kw, jws, jword",  # noqa: F405
         "junos_arg_modifier_kw": (
             '"count" / "forwarding-class" / "ipsec-sa" /"loss-priority" / "policer"'
         ),

--- a/trigger/acl/models.py
+++ b/trigger/acl/models.py
@@ -50,7 +50,7 @@ class BaseModel(pw.Model):
 class CustomCharField(pw.CharField):
     """Overload default CharField to always return strings vs. UTF-8."""
 
-    def coerce(self, value):
+    def coerce(self, value):  # noqa: D102
         return str(value or "")
 
 

--- a/trigger/acl/parser.py
+++ b/trigger/acl/parser.py
@@ -44,31 +44,31 @@ from .support import *  # noqa: F403, E402
 # Exports
 __all__ = (
     # Classes
-    "ACL",
-    "TIP",
+    "ACL",  # noqa: F405
+    "TIP",  # noqa: F405
     "ACLParser",
     "ACLProcessor",
-    "Comment",
-    "Matches",
-    "Policer",
-    "PolicerGroup",
-    "Protocol",
-    "RangeList",
-    "Remark",
-    "S",
-    "Term",
-    "TermList",
+    "Comment",  # noqa: F405
+    "Matches",  # noqa: F405
+    "Policer",  # noqa: F405
+    "PolicerGroup",  # noqa: F405
+    "Protocol",  # noqa: F405
+    "RangeList",  # noqa: F405
+    "Remark",  # noqa: F405
+    "S",  # noqa: F405
+    "Term",  # noqa: F405
+    "TermList",  # noqa: F405
     # Functions
-    "check_range",
+    "check_range",  # noqa: F405
     "default_processor",
-    "do_port_lookup",
-    "do_protocol_lookup",
-    "literals",
+    "do_port_lookup",  # noqa: F405
+    "do_protocol_lookup",  # noqa: F405
+    "literals",  # noqa: F405
     "make_nondefault_processor",
     "parse",
     # Constants,
-    "ports",
-    "strip_comments",
+    "ports",  # noqa: F405
+    "strip_comments",  # noqa: F405
 )
 
 # Temporary resting place for comments, so the rest of the parser can
@@ -98,11 +98,11 @@ def make_nondefault_processor(action):  # noqa: D103
 
         def processor(self, tag_info, buffer):
             tag, start, stop, subtags = tag_info
-            if tag in subtagged:
+            if tag in subtagged:  # noqa: F405
                 results = [
                     getattr(self, subtag[0])(subtag, buffer) for subtag in subtags
                 ]
-                return action(strip_comments(results))
+                return action(strip_comments(results))  # noqa: F405
             return action(buffer[start:stop])
 
     else:
@@ -114,7 +114,7 @@ def make_nondefault_processor(action):  # noqa: D103
 
 
 grammar = []
-for production, rule in rules.items():
+for production, rule in rules.items():  # noqa: F405
     if isinstance(rule, tuple):
         assert len(rule) == 2  # noqa: S101, PLR2004
         setattr(ACLProcessor, production, make_nondefault_processor(rule[1]))
@@ -129,7 +129,7 @@ grammar = "\n".join(grammar)
 class ACLParser(Parser):
     """SimpleParse parser for ACL text."""
 
-    def buildProcessor(self):
+    def buildProcessor(self):  # noqa: D102
         return ACLProcessor()
 
 
@@ -144,7 +144,7 @@ def parse(input_data):
 
     :param input_data:
         An ACL policy as a string or file-like object.
-    """
+    """  # noqa: D205
     parser = ACLParser(grammar)
 
     try:

--- a/trigger/acl/queue.py
+++ b/trigger/acl/queue.py
@@ -6,7 +6,7 @@
     >>> q.list()
     (('dc1-abc.net.aol.com', 'datacenter-protect'), ('dc2-abc.net.aol.com',
     'datacenter-protect'))
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum"
 __maintainer__ = "Jathan McCollum"
@@ -42,7 +42,7 @@ class Queue:
         Boolean
     """
 
-    def __init__(self, verbose=True):
+    def __init__(self, verbose=True):  # noqa: D107
         self.nd = NetDevices()
         self.verbose = verbose
         self.login = get_user()

--- a/trigger/acl/support.py
+++ b/trigger/acl/support.py
@@ -24,7 +24,7 @@ support the various modules for parsing. This file is not meant to by used by it
     'Term',
     'TermList',
     'TIP',
-"""
+"""  # noqa: D205
 
 # Copied metadata from parser.py
 __author__ = "Jathan McCollum, Mike Biancaniello, Michael Harding, Michael Shields"
@@ -60,7 +60,7 @@ def check_name(name, exc, max_len=255, extra_chars=" -_."):
     :param exc: Exception type to raise if the name is invalid.
     :param max_len: Integer of the maximum length of the name.
     :param extra_chars: Extra non-alphanumeric characters to allow in the name.
-    """
+    """  # noqa: D205
     if name is None:
         return
     if name == "":
@@ -117,23 +117,23 @@ def do_protocol_lookup(arg):  # noqa: D103
 
 
 def do_port_lookup(arg):  # noqa: D103
-    return do_lookup(lambda x: ports[x], arg)
+    return do_lookup(lambda x: ports[x], arg)  # noqa: F405
 
 
 def do_icmp_type_lookup(arg):  # noqa: D103
-    return do_lookup(lambda x: icmp_types[x], arg)
+    return do_lookup(lambda x: icmp_types[x], arg)  # noqa: F405
 
 
 def do_icmp_code_lookup(arg):  # noqa: D103
-    return do_lookup(lambda x: icmp_codes[x], arg)
+    return do_lookup(lambda x: icmp_codes[x], arg)  # noqa: F405
 
 
 def do_ip_option_lookup(arg):  # noqa: D103
-    return do_lookup(lambda x: ip_option_names[x], arg)
+    return do_lookup(lambda x: ip_option_names[x], arg)  # noqa: F405
 
 
 def do_dscp_lookup(arg):  # noqa: D103
-    return do_lookup(lambda x: dscp_names[x], arg)
+    return do_lookup(lambda x: dscp_names[x], arg)  # noqa: F405
 
 
 def make_inverse_mask(prefixlen):
@@ -161,9 +161,9 @@ def strip_comments(tags):  # noqa: D103
 class MyDict(dict):
     """A dictionary subclass to collect common behavior changes used in container
     classes for the ACL components: Modifiers, Matches.
-    """
+    """  # noqa: D205
 
-    def __init__(self, d=None, **kwargs):
+    def __init__(self, d=None, **kwargs):  # noqa: D107
         if d:
             if not hasattr(d, "keys"):
                 d = dict(d)
@@ -171,10 +171,10 @@ class MyDict(dict):
         if kwargs:
             self.update(kwargs)
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"<{self.__class__.__name__}: {self!s}>"
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         return ", ".join([f"{k} {v}" for k, v in self.items()])
 
     def update(self, d):
@@ -186,9 +186,9 @@ class MyDict(dict):
 class Modifiers(MyDict):
     """Container class for modifiers. These are only supported by JunOS format
     and are ignored by all others.
-    """
+    """  # noqa: D205
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key, value):  # noqa: D105
         # Handle argument-less modifiers first.
         if key in ("log", "sample", "syslog", "port-mirror"):
             if value not in (None, True):
@@ -240,10 +240,10 @@ class RangeList:
     as it is now?  All the current uses of this class are in this file
     and have unit tests, so when we decided what the semantics of the
     generalized module ought to be, we can make it so without worry.
-    """
+    """  # noqa: D205
 
     # Another way to implement this would be as a radix tree.
-    def __init__(self, data=None):
+    def __init__(self, data=None):  # noqa: D107
         if data is None:
             data = []
 
@@ -282,7 +282,7 @@ class RangeList:
     def _collapse(self, items):
         """Reduce a sorted list of elements to ranges represented as tuples;
         e.g. [1, 2, 3, 4, 10] -> [(1, 4), 10].
-        """
+        """  # noqa: D205
         items = self._cleanup(items)  # Remove duplicates
 
         # Don't bother reducing a single item
@@ -321,7 +321,7 @@ class RangeList:
     def _expand(self, items):
         """Expand a list of elements and tuples back to discrete elements.
         Opposite of _collapse().
-        """
+        """  # noqa: D205
         if not items:
             return items
         try:
@@ -336,11 +336,11 @@ class RangeList:
         """Return a list with all ranges converted to discrete elements."""
         return self._expand(self.data)
 
-    def __add__(self, y):
+    def __add__(self, y):  # noqa: D105
         for elt in y:
             self.append(elt)
 
-    def append(self, obj):
+    def append(self, obj):  # noqa: D102
         # We could make this faster.
         self.data.append(obj)
         self._do_collapse()
@@ -353,34 +353,34 @@ class RangeList:
             return self.data == other
         return NotImplemented
 
-    def __ne__(self, other):
+    def __ne__(self, other):  # noqa: D105
         result = self.__eq__(other)
         if result is NotImplemented:
             return NotImplemented
         return not result
 
-    def __lt__(self, other):
+    def __lt__(self, other):  # noqa: D105
         if isinstance(other, RangeList):
             return self.data < other.data
         if isinstance(other, list):
             return self.data < other
         return NotImplemented
 
-    def __le__(self, other):
+    def __le__(self, other):  # noqa: D105
         if isinstance(other, RangeList):
             return self.data <= other.data
         if isinstance(other, list):
             return self.data <= other
         return NotImplemented
 
-    def __gt__(self, other):
+    def __gt__(self, other):  # noqa: D105
         if isinstance(other, RangeList):
             return self.data > other.data
         if isinstance(other, list):
             return self.data > other
         return NotImplemented
 
-    def __ge__(self, other):
+    def __ge__(self, other):  # noqa: D105
         if isinstance(other, RangeList):
             return self.data >= other.data
         if isinstance(other, list):
@@ -392,7 +392,7 @@ class RangeList:
         * Compare single ports to tuples (i.e. 1700 in (1700, 1800))
         * Compare tuples to tuples (i.e. (1700,1800) in (0,65535))
         * Comparing tuple to integer ALWAYS returns False!!
-        """
+        """  # noqa: D401, D205
         for elt in self.data:
             if isinstance(elt, tuple):
                 if isinstance(obj, tuple):
@@ -412,29 +412,29 @@ class RangeList:
                 return True
         return False
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"<{self.__class__.__name__}: {self.data!s}>"
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         return str(self.data)
 
     # Straight passthrough of these:
-    def __hash__(self):
+    def __hash__(self):  # noqa: D105
         return self.data.__hash__(self.data)
 
-    def __len__(self):
+    def __len__(self):  # noqa: D105
         return len(self.data)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key):  # noqa: D105
         return self.data[key]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key, value):  # noqa: D105
         self.data[key] = value
 
-    def __delitem__(self, key):
+    def __delitem__(self, key):  # noqa: D105
         del self.data[key]
 
-    def __iter__(self):
+    def __iter__(self):  # noqa: D105
         return self.data.__iter__()
 
 
@@ -446,7 +446,7 @@ class TIP(IPy.IP):
     (doesn't interact well with IPy.IP objects). Does not handle IPv6 yet.
     """
 
-    def __init__(self, data, **kwargs):
+    def __init__(self, data, **kwargs):  # noqa: D107
         # Insert logic to handle 'except' preserve negated flag if it exists
         # already
         negated = getattr(data, "negated", False)
@@ -486,7 +486,7 @@ class TIP(IPy.IP):
             self.NoPrefixForSingleIp = False
 
     def _compare_to(self, other):
-        """Helper method for comparison. Returns -1, 0, or 1."""
+        """Helper method for comparison. Returns -1, 0, or 1."""  # noqa: D401
         # Regular IPy sorts by prefix length before network base, but Juniper
         # (our baseline) does not. We also need comparisons to be different for
         # negation. Following Juniper's sorting, use IP compare, and then break
@@ -515,30 +515,30 @@ class TIP(IPy.IP):
         return -1 if self.negated else 1
         # Return the base comparison
 
-    def __lt__(self, other):
+    def __lt__(self, other):  # noqa: D105
         return self._compare_to(other) < 0
 
-    def __le__(self, other):
+    def __le__(self, other):  # noqa: D105
         return self._compare_to(other) <= 0
 
-    def __gt__(self, other):
+    def __gt__(self, other):  # noqa: D105
         return self._compare_to(other) > 0
 
-    def __ge__(self, other):
+    def __ge__(self, other):  # noqa: D105
         return self._compare_to(other) >= 0
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # noqa: D105
         return self._compare_to(other) == 0
 
-    def __ne__(self, other):
+    def __ne__(self, other):  # noqa: D105
         return self._compare_to(other) != 0
 
-    def __hash__(self):
+    def __hash__(self):  # noqa: D105
         # Make TIP hashable for use in sets and as dict keys
         # Base hash on IP address, prefix length, and negation status
         return hash((str(self.ip), self.prefixlen(), self.negated, self.inactive))
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         # Just stick an 'except' at the end if except is set since we don't
         # code to accept this in the constructor really just provided, for now,
         # as a debugging aid.
@@ -555,7 +555,7 @@ class TIP(IPy.IP):
             rs = "'".join(rs)  # Restore original repr
         return rs
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         # IPy is not a new-style class, so the following doesn't work:
         # return super(TIP, self).__str__()  # noqa: ERA001
         rs = IPy.IP.__str__(self)
@@ -580,23 +580,23 @@ class TIP(IPy.IP):
 class Comment:
     """Container for inline comments."""
 
-    def __init__(self, data):
+    def __init__(self, data):  # noqa: D107
         self.data = data
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"<{self.__class__.__name__}: {self.data!r}>"
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         return self.data
 
     def __len__(self):
-        """Defining this method allows null comments to be false."""
+        """Defining this method allows null comments to be false."""  # noqa: D401
         return len(self.data)
 
-    def __iter__(self):
+    def __iter__(self):  # noqa: D105
         return self.data.__iter__()
 
-    def __contains__(self, item):
+    def __contains__(self, item):  # noqa: D105
         return item in self.data
 
     def output_junos(self):
@@ -630,9 +630,9 @@ class Comment:
 class ACL:
     """An abstract access-list object intended to be created by the :func:`parse`
     function.
-    """
+    """  # noqa: D205
 
-    def __init__(
+    def __init__(  # noqa: D107
         self,
         name=None,
         terms=None,
@@ -654,10 +654,10 @@ class ACL:
         self.comments = Comments
         Comments = []
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"<ACL: {self.name}>"
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         return "\n".join(self.output(format=self.format, family=self.family))
 
     def output(self, format=None, *largs, **kwargs):
@@ -841,7 +841,7 @@ class ACL:
                 n += 1
 
     def strip_comments(self):
-        """Strips all comments from ACL header and all terms."""
+        """Strips all comments from ACL header and all terms."""  # noqa: D401
         self.comments = []
         for term in self.terms:
             term.comments = []
@@ -850,7 +850,7 @@ class ACL:
 class Term:
     """An individual term from which an ACL is made."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, D107
         self,
         name=None,
         action="accept",
@@ -880,25 +880,25 @@ class Term:
         self.comments = Comments
         Comments = []
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"<Term: {self.name}>"
 
-    def getname(self):
+    def getname(self):  # noqa: D102
         return self.__name
 
-    def setname(self, name):
+    def setname(self, name):  # noqa: D102
         check_name(name, exceptions.BadTermName)
         self.__name = name
 
-    def delname(self):
+    def delname(self):  # noqa: D102
         self.name = None
 
     name = property(getname, setname, delname)
 
-    def getaction(self):
+    def getaction(self):  # noqa: D102
         return self.__action
 
-    def setaction(self, action):
+    def setaction(self, action):  # noqa: D102
         if action is None:
             action = "accept"
         if action == "next term":
@@ -918,9 +918,9 @@ class Term:
         elif action == ("deny",):
             self.__action = ("reject",)
         elif action[0] == "reject":
-            if action[1] not in icmp_reject_codes:
+            if action[1] not in icmp_reject_codes:  # noqa: F405
                 raise exceptions.BadRejectCode("invalid rejection code " + action[1])
-            if action[1] == icmp_reject_codes[0]:
+            if action[1] == icmp_reject_codes[0]:  # noqa: F405
                 action = ("reject",)
             self.__action = action
         elif action[0] == "routing-instance":
@@ -930,7 +930,7 @@ class Term:
             msg = f'unknown action "{action!s}"'
             raise exceptions.UnknownActionName(msg)
 
-    def delaction(self):
+    def delaction(self):  # noqa: D102
         self.action = "accept"
 
     action = property(getaction, setaction, delaction)
@@ -938,7 +938,7 @@ class Term:
     def set_action_or_modifier(self, action):
         """Add or replace a modifier, or set the primary action. This method exists
         for the convenience of parsers.
-        """
+        """  # noqa: D205
         try:
             self.action = action
         except exceptions.UnknownActionName:
@@ -992,7 +992,7 @@ class Term:
             action = "deny "
         else:
             msg = '"{}" action not supported by IOS'.format(" ".join(self.action))
-            raise VendorSupportLacking(
+            raise VendorSupportLacking(  # noqa: F405
                 msg,
             )
         suffix = ""
@@ -1052,7 +1052,7 @@ class TermList(list):
 class Protocol:
     """A protocol object used for access membership tests in :class:`Term` objects.
     Acts like an integer, but stringify into a name if possible.
-    """
+    """  # noqa: D205
 
     num2name: ClassVar[dict[int, str]] = {
         1: "icmp",
@@ -1075,7 +1075,7 @@ class Protocol:
     name2num: ClassVar[dict[str, int]] = {v: k for k, v in num2name.items()}
     name2num["ahp"] = 51  # undocumented Cisco special name
 
-    def __init__(self, arg):
+    def __init__(self, arg):  # noqa: D107
         if isinstance(arg, Protocol):
             self.value = arg.value
         elif arg in Protocol.name2num:
@@ -1083,16 +1083,16 @@ class Protocol:
         else:
             self.value = int(arg)
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         if self.value in Protocol.num2name:
             return Protocol.num2name[self.value]
         return str(self.value)
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"<{self.__class__.__name__}: {self!s}>"
 
     def _get_compare_value(self, other):
-        """Helper to get comparison value from other."""
+        """Helper to get comparison value from other."""  # noqa: D401
         try:
             return Protocol(other).value
         except (ValueError, TypeError):
@@ -1105,37 +1105,37 @@ class Protocol:
             return NotImplemented
         return self.value == other_value
 
-    def __ne__(self, other):
+    def __ne__(self, other):  # noqa: D105
         result = self.__eq__(other)
         if result is NotImplemented:
             return NotImplemented
         return not result
 
-    def __lt__(self, other):
+    def __lt__(self, other):  # noqa: D105
         other_value = self._get_compare_value(other)
         if other_value is NotImplemented:
             return NotImplemented
         return self.value < other_value
 
-    def __le__(self, other):
+    def __le__(self, other):  # noqa: D105
         other_value = self._get_compare_value(other)
         if other_value is NotImplemented:
             return NotImplemented
         return self.value <= other_value
 
-    def __gt__(self, other):
+    def __gt__(self, other):  # noqa: D105
         other_value = self._get_compare_value(other)
         if other_value is NotImplemented:
             return NotImplemented
         return self.value > other_value
 
-    def __ge__(self, other):
+    def __ge__(self, other):  # noqa: D105
         other_value = self._get_compare_value(other)
         if other_value is NotImplemented:
             return NotImplemented
         return self.value >= other_value
 
-    def __hash__(self):
+    def __hash__(self):  # noqa: D105
         return hash(self.value)
 
     def __getattr__(self, name):
@@ -1146,9 +1146,9 @@ class Protocol:
 class Matches(MyDict):
     """Container class for Term.match object used for membership tests on
     access checks.
-    """
+    """  # noqa: D205
 
-    def __setitem__(self, key, arg):  # noqa: PLR0912, PLR0915
+    def __setitem__(self, key, arg):  # noqa: PLR0912, PLR0915, D105
         if key in (
             "ah-spi",
             "destination-mac-address",
@@ -1207,11 +1207,11 @@ class Matches(MyDict):
         elif key in ("prefix-list", "source-prefix-list", "destination-prefix-list"):
             for pl in arg:
                 check_name(pl, exceptions.MatchError)
-        elif key in tcp_flag_specials:
+        elif key in tcp_flag_specials:  # noqa: F405
             # This cannot be the final form of how to represent tcp-flags.
             # Instead, we need to implement a real parser for it.
             # See: http://www.juniper.net/techpubs/software/junos/junos73/swconfig73-policy/html/firewall-config14.html
-            arg = [tcp_flag_specials[key]]
+            arg = [tcp_flag_specials[key]]  # noqa: F405
             key = "tcp-flags"
         elif key == "tcp-flags":
             pass
@@ -1248,7 +1248,7 @@ class Matches(MyDict):
 
         :param pair:
             The 2-tuple to convert.
-        """
+        """  # noqa: D205
         try:
             return "%s-%s" % pair  # noqa: UP031  # Tuples back to ranges.
         except TypeError:
@@ -1306,12 +1306,12 @@ class Matches(MyDict):
         """Return a list that can form the ``from { ... }`` clause of the term."""
         a = []
         # Python 3: dict.keys() returns a view, convert to list for sorting
-        keys = sorted(self.keys(), key=lambda x: junos_match_order.get(x, 999))
+        keys = sorted(self.keys(), key=lambda x: junos_match_order.get(x, 999))  # noqa: F405
         for s in keys:
             # Python 3: map() returns an iterator, convert to list
             matches = list(map(self.junos_str, self[s]))
             has_negated_addrs = any(m for m in matches if m.endswith(" except"))
-            if s in address_matches:
+            if s in address_matches:  # noqa: F405
                 # Check to see if any of the added is any, and if so break out,
                 # but only if none of the addresses is "negated".
                 if "0.0.0.0/0" in matches and not has_negated_addrs:
@@ -1322,7 +1322,7 @@ class Matches(MyDict):
                 continue
             if s == "tcp-flags" and len(self[s]) == 1:
                 try:
-                    a.append(tcp_flag_rev[self[s][0]] + ";")
+                    a.append(tcp_flag_rev[self[s][0]] + ";")  # noqa: F405
                     continue
                 except KeyError:
                     pass
@@ -1359,12 +1359,12 @@ class Matches(MyDict):
                     if "icmp-code" in self:
                         for code in self["icmp-code"]:
                             try:
-                                destports.append(ios_icmp_names[(type, code)])
+                                destports.append(ios_icmp_names[(type, code)])  # noqa: F405
                             except KeyError:  # noqa: PERF203
                                 destports.append("%d %d" % (type, code))  # noqa: UP031
                     else:
                         try:
-                            destports.append(ios_icmp_names[(type,)])
+                            destports.append(ios_icmp_names[(type,)])  # noqa: F405
                         except KeyError:
                             destports.append(str(type))
             elif key == "icmp-code":
@@ -1372,7 +1372,7 @@ class Matches(MyDict):
                     msg = "need ICMP code w/type"
                     raise exceptions.VendorSupportLacking(msg)
             elif key == "tcp-flags":
-                if arg != [tcp_flag_specials["tcp-established"]]:
+                if arg != [tcp_flag_specials["tcp-established"]]:  # noqa: F405
                     msg = 'IOS supports only "tcp-flags established"'
                     raise exceptions.VendorSupportLacking(
                         msg,

--- a/trigger/acl/tools.py
+++ b/trigger/acl/tools.py
@@ -1,6 +1,6 @@
 """Various tools for use in scripts or other modules. Heavy lifting from tools
 that have matured over time have been moved into this module.
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum, Eileen Tschetter"
 __maintainer__ = "Jathan McCollum"
@@ -52,7 +52,7 @@ def create_trigger_term(  # noqa: PLR0913
     action=None,
     name="generated_term",
 ):
-    """Constructs & returns a Term object from constituent parts."""
+    """Constructs & returns a Term object from constituent parts."""  # noqa: D401
     if action is None:
         action = ["accept"]
     if protocols is None:
@@ -65,7 +65,7 @@ def create_trigger_term(  # noqa: PLR0913
         dest_ips = []
     if source_ips is None:
         source_ips = []
-    term = Term()
+    term = Term()  # noqa: F405
     term.action = action
     term.name = name
     for key, data in {
@@ -118,12 +118,12 @@ def check_access(terms_to_check, new_term, quiet=True, format="junos", acl_name=
     def _permitted_in_term(term, comment=" check_access: PERMITTED HERE"):
         """A little closure to re-use internally that returns a Boolean based
         on the given Term object's action.
-        """
+        """  # noqa: D401, D205
         action = term.action[0]
         if action == "accept":
             is_permitted = True
             if not quiet:
-                term.comments.append(Comment(comment))
+                term.comments.append(Comment(comment))  # noqa: F405
 
         elif action in ("discard", "reject"):
             is_permitted = False
@@ -194,7 +194,7 @@ def create_access(terms_to_check, new_term):
     compared in a check_access test.
 
     Returns a list of terms that should be inserted.
-    """
+    """  # noqa: D401, D205
     protos = new_term.match.get("protocol", ["any"])
     sources = new_term.match.get("source-address", ["any"])
     dests = new_term.match.get("destination-address", ["any"])
@@ -207,7 +207,7 @@ def create_access(terms_to_check, new_term):
             for sourceport in sourceports:
                 for dest in dests:
                     for destport in destports:
-                        t = Term()
+                        t = Term()  # noqa: F405
                         if str(proto) != "any":
                             t.match["protocol"] = [proto]
                         if str(source) != "any":
@@ -248,8 +248,8 @@ def insert_term_into_acl(new_term, aclobj, debug=False):  # noqa: PLR0912
         new_acl = copy.deepcopy(original_acl) # Dupe the original
         for term in terms_to_be_added:
             new_acl = generate_new_acl(term, new_acl)
-    """
-    new_acl = ACL()  # ACL comes from trigger.acl.parser
+    """  # noqa: D205
+    new_acl = ACL()  # ACL comes from trigger.acl.parser  # noqa: F405
     new_acl.policers = aclobj.policers
     new_acl.format = aclobj.format
     new_acl.name = aclobj.name
@@ -336,9 +336,9 @@ def create_new_acl(old_file, terms_to_be_added):
     """Given a list of Term objects call insert_term_into_acl() to determine
     what needs to be added in based on the contents of old_file. Returns a new
     ACL object.
-    """
+    """  # noqa: D205
     with Path(old_file).open() as fh:
-        aclobj = parse(fh)  # Start with the original ACL contents
+        aclobj = parse(fh)  # Start with the original ACL contents  # noqa: F405
     new_acl = None
     for new_term in terms_to_be_added:
         new_acl = insert_term_into_acl(new_term, aclobj)
@@ -347,7 +347,7 @@ def create_new_acl(old_file, terms_to_be_added):
 
 
 def get_bulk_acls():
-    """Returns a dict of acls with an applied count over settings.AUTOLOAD_BULK_THRESH."""
+    """Returns a dict of acls with an applied count over settings.AUTOLOAD_BULK_THRESH."""  # noqa: D401
     from trigger.netdevices import NetDevices
 
     nd = NetDevices()
@@ -431,7 +431,7 @@ def process_bulk_loads(work, max_hits=settings.BULK_MAX_HITS_DEFAULT, force_bulk
                     )
                     print(msg)
                     if "log" in globals():
-                        log.msg(msg)
+                        log.msg(msg)  # noqa: F405
 
                     # Remove that acl from being loaded, but still load on that device
                     work[dev].remove(acl)
@@ -535,9 +535,9 @@ def worklog(title, diff, log_string="updated by express-gen"):
 class ACLScript:
     """Interface to generating or modifying access-lists. Intended for use in
     creating command-line utilities using the ACL API.
-    """
+    """  # noqa: D205
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, D107
         self,
         acl=None,
         mode="insert",
@@ -561,11 +561,11 @@ class ACLScript:
         self.no_worklog = no_worklog
         self.no_changes = no_changes
 
-    def cleanup(self):
+    def cleanup(self):  # noqa: D102
         for file in self.tempfiles:
             Path(file).unlink()
 
-    def genargs(self, interactive=False):  # noqa: PLR0912
+    def genargs(self, interactive=False):  # noqa: PLR0912, D102
         if not self.acl:
             msg = "need acl defined"
             raise ValueError(msg)
@@ -633,10 +633,10 @@ class ACLScript:
 
         return argz
 
-    def parselog(self, log):
+    def parselog(self, log):  # noqa: D102
         return log
 
-    def run(self, interactive=False):
+    def run(self, interactive=False):  # noqa: D102
         args = self.genargs(interactive=interactive)
         log = []
         # print self.cmd + ' ' + ' '.join(args)
@@ -651,7 +651,7 @@ class ACLScript:
                 line = f.readline()
         return log
 
-    def errors_from_log(self, log):
+    def errors_from_log(self, log):  # noqa: D102
         errors = ""
         for line in log:
             if "%%ERROR%%" in line:
@@ -659,7 +659,7 @@ class ACLScript:
                 errors += line[1:] + "\n"
         return errors
 
-    def diff_from_log(self, log):
+    def diff_from_log(self, log):  # noqa: D102
         diff = ""
         for line in log:
             if "%%DIFF%%" in line:
@@ -667,7 +667,7 @@ class ACLScript:
                 diff += line[1:] + "\n"
         return diff
 
-    def set_acl(self, acl):
+    def set_acl(self, acl):  # noqa: D102
         self.acl = acl
 
     def _add_addr(self, to, src):
@@ -686,7 +686,7 @@ class ACLScript:
         elif int(src) not in to:
             to.append(int(src))
 
-    def add_protocol(self, src):
+    def add_protocol(self, src):  # noqa: D102
         to = self.protocol
         if isinstance(src, list):
             for x in src:
@@ -695,40 +695,40 @@ class ACLScript:
         elif src not in to:
             to.append(src)
 
-    def add_src_host(self, data):
+    def add_src_host(self, data):  # noqa: D102
         self._add_addr(self.source_ips, data)
 
-    def add_dst_host(self, data):
+    def add_dst_host(self, data):  # noqa: D102
         self._add_addr(self.dest_ips, data)
 
-    def add_src_port(self, data):
+    def add_src_port(self, data):  # noqa: D102
         self._add_port(self.source_ports, data)
 
-    def add_dst_port(self, data):
+    def add_dst_port(self, data):  # noqa: D102
         self._add_port(self.dest_ports, data)
 
-    def add_modify_between_comments(self, begin, end):
+    def add_modify_between_comments(self, begin, end):  # noqa: D102
         del self.modify_terms
         self.modify_terms = []
         self.bcomments.append((begin, end))
 
-    def add_modify_term(self, term):
+    def add_modify_term(self, term):  # noqa: D102
         del self.bcomments
         self.bcomments = []
         if term not in self.modify_terms:
             self.modify_terms.append(term)
 
-    def get_protocols(self):
+    def get_protocols(self):  # noqa: D102
         return self.protocol
 
-    def get_src_hosts(self):
+    def get_src_hosts(self):  # noqa: D102
         return self.source_ips
 
-    def get_dst_hosts(self):
+    def get_dst_hosts(self):  # noqa: D102
         return self.dest_ips
 
-    def get_src_ports(self):
+    def get_src_ports(self):  # noqa: D102
         return self.source_ports
 
-    def get_dst_ports(self):
+    def get_dst_ports(self):  # noqa: D102
         return self.dest_ports

--- a/trigger/bin/acl.py
+++ b/trigger/bin/acl.py
@@ -126,7 +126,7 @@ def p_error(optp, msg=None):  # noqa: D103
 
 
 def main():  # noqa: PLR0912, PLR0915
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     # Setup
     aclsdb = AclsDB()
     term_width = get_terminal_width()  # How wide is your term!

--- a/trigger/bin/acl_script.py
+++ b/trigger/bin/acl_script.py
@@ -460,7 +460,7 @@ def wedge_acl(acl, new_term, between, opts):  # noqa: D103, PLR0912, PLR0915
 
 
 def main():  # noqa: PLR0912, PLR0915
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     opts, _args = parse_args(sys.argv)
     for acl_file in opts.acl:
         rcs = RCS(acl_file, create=False)

--- a/trigger/bin/aclconv.py
+++ b/trigger/bin/aclconv.py
@@ -19,7 +19,7 @@ formats = {
 
 
 def main():  # noqa: PLR0912
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     optp = optparse.OptionParser(
         description="""\
 Convert an ACL on stdin, or a list of ACLs, from one format to another.

--- a/trigger/bin/check_access.py
+++ b/trigger/bin/check_access.py
@@ -14,7 +14,7 @@ from trigger.acl.tools import check_access, create_trigger_term
 
 
 def main():
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     optp = optparse.OptionParser(
         description="""\
 Determine whether access is permitted by a given ACL.  Exits 0 if permitted,

--- a/trigger/bin/check_syntax.py
+++ b/trigger/bin/check_syntax.py
@@ -30,7 +30,7 @@ def parse_args(argv):  # noqa: D103
 
 
 def main():
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     global opts
 
     fd, _tmpfile = tempfile.mkstemp(suffix="_parsing_check")

--- a/trigger/bin/fe.py
+++ b/trigger/bin/fe.py
@@ -90,7 +90,7 @@ def edit(editfile):
     """Edits the file and calls normalize(). Loops until it passes or the user
     confirms they want to bypass failed normalization. Returns a file object of
     the diff output.
-    """
+    """  # noqa: D205
     editor = os.environ.get("EDITOR", "vim")
     if editor.startswith("vi"):
         os.spawnlp(
@@ -128,7 +128,7 @@ def edit(editfile):
 
 
 def main():  # noqa: PLR0912, PLR0915
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     if len(sys.argv) < 2:  # noqa: PLR2004
         print("usage: fe files...", file=sys.stderr)
         sys.exit(2)

--- a/trigger/bin/find_access.py
+++ b/trigger/bin/find_access.py
@@ -113,17 +113,17 @@ def match_terms(acl, sources, dests, ports, opts):  # noqa: D103
 
 
 def permits_from_any(term):
-    """Returns True if action is "accept" and term has no 'source-address'."""
+    """Returns True if action is "accept" and term has no 'source-address'."""  # noqa: D401
     return term.action[0] == "accept" and not term.match.get("source-address")
 
 
 def any_source(term):
-    """Returns True term has no 'source-address'."""
+    """Returns True term has no 'source-address'."""  # noqa: D401
     return not term.match.get("source-address")
 
 
 def any_dest(term):
-    """Returns True term has no 'destination-address'."""
+    """Returns True term has no 'destination-address'."""  # noqa: D401
     return not term.match.get("destination-address")
 
 
@@ -170,7 +170,7 @@ def print_report(data):  # noqa: D103
 
 
 def main():
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     opts, args = parse_args(sys.argv)
 
     acls_to_check = args[1:]

--- a/trigger/bin/gnng.py
+++ b/trigger/bin/gnng.py
@@ -115,7 +115,7 @@ default. Works on Cisco, Foundry, Juniper, and NetScreen devices.""",
 def fetch_router_list(args, opts):
     """Turns a list of device names into device objects, skipping unsupported,
     invalid, or filtered devices.
-    """
+    """  # noqa: D401, D205
     nd = NetDevices(production_only=opts.nonprod)
     ret = []
     blocked_groups = []
@@ -139,7 +139,7 @@ def fetch_router_list(args, opts):
 
 
 def pass_filters(device, opts):
-    """Used by fetch_router_list() to filter a device based on command-line arguments."""
+    """Used by fetch_router_list() to filter a device based on command-line arguments."""  # noqa: D401
     if opts.filter_on_group and device.owningTeam not in opts.filter_on_group:
         return False
     return not (opts.filter_on_type and device.deviceType not in opts.filter_on_type)
@@ -396,7 +396,7 @@ def output_dotty(subnet_table, display=True):
 
 
 def main():
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     opts, args = parse_args(sys.argv)
 
     if opts.all or opts.filter_on_type:

--- a/trigger/bin/gong.py
+++ b/trigger/bin/gong.py
@@ -58,7 +58,7 @@ def connect_to_oob(dev):
 
 
 def main():
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     global opts
     opts, args = parse_args(sys.argv)
 

--- a/trigger/bin/load_acl.py
+++ b/trigger/bin/load_acl.py
@@ -80,7 +80,7 @@ def draw_screen(s, work, active, failures, start_qlen, start_time):  # noqa: PLR
 
     :param start_time:
         The epoch time at startup (to calculate progress)
-    """
+    """  # noqa: D205
     global output_cache  # noqa: PLW0602
 
     if not s:
@@ -157,7 +157,7 @@ def parse_args(argv):
 
     :param argv:
         A list of opts/args to use over sys.argv
-    """
+    """  # noqa: D401, D205
 
     def comma_cb(option, opt_str, value, parser):
         """OptionParser callback to handle comma-separated arguments."""
@@ -275,7 +275,7 @@ def parse_args(argv):
 
 
 def debug_fakeout():
-    """Used for debug, but this method is rarely used."""
+    """Used for debug, but this method is rarely used."""  # noqa: D401
     return os.getenv("DEBUG_FAKEOUT") is not None
 
 
@@ -289,7 +289,7 @@ def get_work(opts, args):  # noqa: PLR0912, PLR0915
 
     :param args:
         A list of CLI arguments
-    """
+    """  # noqa: D205
     # removing acl. assumption from files
     aclargs = set(
         args[1:],
@@ -299,7 +299,7 @@ def get_work(opts, args):  # noqa: PLR0912, PLR0915
     bulk_acls = get_bulk_acls()
 
     def add_work(dev_name, acls):
-        """A closure for the purpose of adding/updating ACLS for a given device."""
+        """A closure for the purpose of adding/updating ACLS for a given device."""  # noqa: D401
         try:
             dev = nd[dev_name]
         except KeyError:
@@ -438,7 +438,7 @@ def junoscript_cmds(acls_content, tftp_paths, dev):
 
     :param dev:
         A Juniper `~trigger.netdevices.NetDevice` object
-    """
+    """  # noqa: D205
     xml = [Element("lock-configuration")]
     status = ["locking configuration"]
 
@@ -472,7 +472,7 @@ def ioslike_cmds(tftp_paths, dev, opts):  # , nonce):
 
     :param nonce:
         A nonce to use when staging the ACL file for TFTP
-    """
+    """  # noqa: D205
     template_base = {
         "arista": "copy tftp://%s/%s system:/running-config\n",
         "cisco": "copy tftp://%s/%s system:/running-config\n",
@@ -507,7 +507,7 @@ def group(dev):
 
     :param dev:
         The `~trigger.netdevices.NetDevice` object to try to group
-    """
+    """  # noqa: D401, D205
     # TODO(jathan): Make this pattern configurable globally.
     trimmer = re.compile("[0-9]*[a-z]+")  # allow for e.g. "36bit1"
 
@@ -536,7 +536,7 @@ def select_next_device(work, active):
 
     :param active:
         Dictionary mapping running devs to human-readable status
-    """
+    """  # noqa: D205
     active_groups = set([group(dev) for dev in active])
     for dev in work:
         if group(dev) not in active_groups:
@@ -669,7 +669,7 @@ def run(stdscr, work, jobs, failures, opts):
 
     :param failures:
         Dictionary of failures
-    """
+    """  # noqa: D401
     # Dictionary of currently running devs -> human-readable status
     active = {}
 
@@ -677,7 +677,7 @@ def run(stdscr, work, jobs, failures, opts):
     start_time = time.time()
 
     def redraw():
-        """A closure to redraw the screen with current environment."""
+        """A closure to redraw the screen with current environment."""  # noqa: D401
         draw_screen(stdscr, work, active, failures, start_qlen, start_time)
 
     activate(work, active, failures, jobs, redraw, opts)
@@ -690,7 +690,7 @@ def run(stdscr, work, jobs, failures, opts):
 
 
 def main():  # noqa: PLR0912, PLR0915
-    """The Main Event."""
+    """The Main Event."""  # noqa: D401
     global opts
     opts, args = parse_args(sys.argv)
 

--- a/trigger/bin/load_config.py
+++ b/trigger/bin/load_config.py
@@ -9,7 +9,7 @@ from trigger.contrib import docommand
 
 
 def main():
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     docommand.main(action_class=docommand.ConfigLoader)
 
 

--- a/trigger/bin/netdev.py
+++ b/trigger/bin/netdev.py
@@ -13,7 +13,7 @@ from trigger.netdevices import NetDevices, device_match
 def parse_args(argv):
     """Parse arguments, duh. There is a better way to do this using Twisted's
     usage module, but replacing it is not a high priority.
-    """
+    """  # noqa: D205
     parser = OptionParser(
         usage="%prog [options]",
         description="\nCommand-line search interface for 'NetDevices' metadata.",
@@ -179,7 +179,7 @@ def parse_args(argv):
 def search_builder(opts):  # noqa: PLR0912, PLR0915
     """Builds a list comprehension from the options passed at command-line and
     then evaluates it to return a list of matching device names.
-    """
+    """  # noqa: D401, D205
     NetDevices(production_only=opts.nonprod)
 
     query = "[x for x in nd.all()"
@@ -304,7 +304,7 @@ def search_builder(opts):  # noqa: PLR0912, PLR0915
 
 
 def main():
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     _opts, _args = parse_args(sys.argv)
 
 

--- a/trigger/bin/optimizer.py
+++ b/trigger/bin/optimizer.py
@@ -132,7 +132,7 @@ is set to 0 (or off).
 class ProgressMeter:
     """Display progress during ACL optimization."""
 
-    def __init__(self, **kw):
+    def __init__(self, **kw):  # noqa: D107
         # What time do we start tracking our progress from?
         self.timestamp = kw.get("timestamp", time.time())
         # What kind of unit are we tracking?
@@ -155,7 +155,7 @@ class ProgressMeter:
         self.last_refresh = 0
         self.prev_meter_len = 0
 
-    def update(self, count, **kw):
+    def update(self, count, **kw):  # noqa: D102
         now = time.time()
         # Caclulate rate of progress
         rate = 0.0
@@ -190,13 +190,13 @@ class ProgressMeter:
         else:
             self.refresh()
 
-    def get_meter(self, **kw):
+    def get_meter(self, **kw):  # noqa: D102
         bar = "-" * self.meter_value
         pad = " " * (self.meter_ticks - self.meter_value)
         perc = (float(self.count) / self.total) * 100
         return "[%s>%s] %d%%  %.1f/sec" % (bar, pad, perc, self.rate_current)  # noqa: UP031
 
-    def refresh(self, **kw):
+    def refresh(self, **kw):  # noqa: D102
         # Clear line and return cursor to start-of-line
         sys.stderr.write(" " * self.prev_meter_len + "\x08" * self.prev_meter_len)
         # Get meter text
@@ -216,7 +216,7 @@ class ProgressMeter:
 def focus_terms(pcount, terms):  # noqa: PLR0912
     """Generates a list of term names that have a port count
     greater than pcount for the optimizer to 'focus' in on.
-    """
+    """  # noqa: D401, D205
     focused = dict()
     matched_ports = dict()
     ports = dict()
@@ -612,7 +612,7 @@ def do_work(opts, files):  # noqa: D103, PLR0912, PLR0915
 
 
 def main():
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     opts, args = parse_args(sys.argv)
     if opts.debug:
         log.setLevel(logging.DEBUG)

--- a/trigger/bin/run_cmds.py
+++ b/trigger/bin/run_cmds.py
@@ -9,7 +9,7 @@ from trigger.contrib import docommand
 
 
 def main():
-    """Main entry point for the CLI tool."""
+    """Main entry point for the CLI tool."""  # noqa: D401
     docommand.main(action_class=docommand.CommandRunner)
 
 

--- a/trigger/changemgmt/__init__.py
+++ b/trigger/changemgmt/__init__.py
@@ -52,46 +52,46 @@ class BounceStatus:
         The colored risk-level status name.
     """
 
-    def __init__(self, status_name):
+    def __init__(self, status_name):  # noqa: D107
         self.status_name = status_name
         self.value = BOUNCE_VALUES.index(status_name)
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"<{self.__class__.__name__}: {self.status_name}>"
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         return self.status_name
 
     def _get_compare_value(self, other):
-        """Helper to get comparison value from self or other."""
+        """Helper to get comparison value from self or other."""  # noqa: D401
         try:
             return other.value
         except AttributeError:
             # Other object is not a BounceStatus; maybe it's a string.
             return BounceStatus(other).value
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # noqa: D105
         try:
             return self.value == self._get_compare_value(other)
         except (ValueError, KeyError):
             return False
 
-    def __ne__(self, other):
+    def __ne__(self, other):  # noqa: D105
         return not self.__eq__(other)
 
-    def __lt__(self, other):
+    def __lt__(self, other):  # noqa: D105
         return self.value < self._get_compare_value(other)
 
-    def __le__(self, other):
+    def __le__(self, other):  # noqa: D105
         return self.value <= self._get_compare_value(other)
 
-    def __gt__(self, other):
+    def __gt__(self, other):  # noqa: D105
         return self.value > self._get_compare_value(other)
 
-    def __ge__(self, other):
+    def __ge__(self, other):  # noqa: D105
         return self.value >= self._get_compare_value(other)
 
-    def __hash__(self):
+    def __hash__(self):  # noqa: D105
         return hash((self.status_name, self.value))
 
 
@@ -174,7 +174,7 @@ class BounceWindow:
     # Prepopulate these objects to save a little horsepower
     BOUNCE_STATUS: ClassVar[dict] = {n: BounceStatus(n) for n in BOUNCE_VALUES}
 
-    def __init__(
+    def __init__(  # noqa: D107
         self,
         status_by_hour=None,
         green=None,
@@ -213,7 +213,7 @@ class BounceWindow:
                 raise exceptions.InvalidBounceWindow(msg)
         self._status_by_hour = status_by_hour
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"{self.__class__.__name__}(green={self._green!r}, yellow={self._yellow!r}, red={self._red!r}, default={self.default!r})"
 
     def status(self, when=None):
@@ -222,7 +222,7 @@ class BounceWindow:
 
         :param when:
             A ``datetime`` object.
-        """
+        """  # noqa: D205
         when_et = (when or datetime.now(tz=UTC)).astimezone(BOUNCE_DEFAULT_TZ)
 
         # Return default during weekend moratorium, otherwise look it up.
@@ -246,7 +246,7 @@ class BounceWindow:
 
         :param when:
             A ``datetime`` object.
-        """
+        """  # noqa: D205
         when = when or datetime.now(tz=UTC)
         if self.status(when) <= status:
             return when.astimezone(UTC)
@@ -280,7 +280,7 @@ class BounceWindow:
 
         :param default:
             The default bounce status name.
-        """
+        """  # noqa: D205
         if default is None:
             default = self.default
         status = []
@@ -305,7 +305,7 @@ class BounceWindow:
 
         :param hs:
             A string representation of hours.
-        """
+        """  # noqa: D205
         myhours = []
         if hs is None:
             return myhours

--- a/trigger/cmds.py
+++ b/trigger/cmds.py
@@ -4,7 +4,7 @@ data for rapid integration to existing or newly-created tools.
 
 The `~trigger.cmds.Commando` class is designed to be extended but can still be
 used as-is to execute commands and return the results as-is.
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum, Eileen Tschetter, Mark Thomas"
 __maintainer__ = "Jathan McCollum"
@@ -144,7 +144,7 @@ class Commando:
     # Whether to stop the reactor when all results have returned.
     stop_reactor = None
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, D107
         self,
         devices=None,
         commands=None,
@@ -196,7 +196,7 @@ class Commando:
     def _validate_platforms(self):
         """Determine the set of supported platforms for this instance by making
         sure the specified vendors/platforms for the class match up.
-        """
+        """  # noqa: D205
         supported_platforms = {}
         for vendor in self.vendors:
             if vendor in self.platforms:
@@ -219,7 +219,7 @@ class Commando:
         """Self-explanatory. Called by _add_worker() as both callback/errback
         so we can accurately refill the jobs queue, which relies on the
         current connection count.
-        """
+        """  # noqa: D205
         self.curr_conns -= 1
         return data
 
@@ -229,7 +229,7 @@ class Commando:
         return True
 
     def _setup_jobs(self):
-        """Maps device hostnames to `~trigger.netdevices.NetDevice` objects and populates the job queue."""
+        """Maps device hostnames to `~trigger.netdevices.NetDevice` objects and populates the job queue."""  # noqa: D401
         for dev in self.devices:
             log.msg("Adding", dev)
             if self.verbose:
@@ -281,7 +281,7 @@ class Commando:
     def _add_worker(self):
         """Adds devices to the work queue to keep it populated with the maximum
         connections as specified by ``max_conns``.
-        """
+        """  # noqa: D401, D205
         while self.jobs and self.curr_conns < self.max_conns:
             device = self.select_next_device()
             if device is None:
@@ -423,7 +423,7 @@ class Commando:
         :param extra:
             (Optional) A dictionary of extra data to send to the generate
             method for the device.
-        """
+        """  # noqa: D205
         if commands is None:
             commands = self.commands
         if extra is None:
@@ -444,7 +444,7 @@ class Commando:
             NetDevice object
         :type device:
             `~trigger.netdevices.NetDevice`
-        """
+        """  # noqa: D401, D205
         device_type = device.os
         ret = []
 
@@ -489,7 +489,7 @@ class Commando:
             class constructor.
         :type commands:
             list
-        """
+        """  # noqa: D205
         func = self._lookup_method(device, method="parse")
         return func(results, device, commands)
 
@@ -502,7 +502,7 @@ class Commando:
 
         :param device:
             A `~trigger.netdevices.NetDevice` object
-        """
+        """  # noqa: D401, D205
         failure.trap(Exception)
         self.store_error(device, failure)
         return failure
@@ -520,7 +520,7 @@ class Commando:
         :param error:
             The error to store. Anything you want really, but usually a Twisted
             ``Failure`` instance.
-        """
+        """  # noqa: D401, D205
         devname = str(device)
         self.errors[devname] = error
         return True
@@ -537,7 +537,7 @@ class Commando:
 
         :param results:
             The results to store. Anything you want really.
-        """
+        """  # noqa: D401, D205
         devname = str(device)
         log.msg(f"Appending results for {devname!r}: {results!r}")
         if self.parsed_results.get(devname):
@@ -558,7 +558,7 @@ class Commando:
 
         :param results:
             The results to store. Anything you want really.
-        """
+        """  # noqa: D401, D205
         devname = str(device)
         log.msg(f"Storing results for {devname!r}: {results!r}")
         self.results[devname] = results
@@ -627,12 +627,12 @@ class Commando:
     # =======================================
     # Base generate (to_)/parse (from_) methods
     # =======================================
-    def to_base(self, device, commands=None, extra=None):
+    def to_base(self, device, commands=None, extra=None):  # noqa: D102
         commands = commands or self.commands
         log.msg(f"Sending {commands!r} to {device}")
         return commands
 
-    def from_base(self, results, device, commands=None):
+    def from_base(self, results, device, commands=None):  # noqa: D102
         commands = commands or self.commands
         log.msg(f"Received {results!r} from {device}")
         self.store_results(device, self.map_results(commands, results))
@@ -643,7 +643,7 @@ class Commando:
     def to_juniper(self, device, commands=None, extra=None):
         """Creates a series of ``<command>foo</command>`` elements to
         pass along to execute_junoscript().
-        """
+        """  # noqa: D401, D205
         commands = commands or self.commands
 
         # If we've set force_cli, use to_base() instead
@@ -697,12 +697,12 @@ class ReactorlessCommando(Commando):
     """
 
     def _start(self):
-        """Initializes ``all_done`` instead of starting the reactor."""
+        """Initializes ``all_done`` instead of starting the reactor."""  # noqa: D401
         log.msg("._start() called")
         self.all_done = False
 
     def _stop(self):
-        """Sets ``all_done`` to True instead of stopping the reactor."""
+        """Sets ``all_done`` to True instead of stopping the reactor."""  # noqa: D401
         log.msg("._stop() called")
         self.all_done = True
 
@@ -731,7 +731,7 @@ class ReactorlessCommando(Commando):
     def monitor_result(self, result, reactor):
         """Loop periodically or until the factory stops to check if we're
         ``all_done`` and then return the results.
-        """
+        """  # noqa: D205
         # Once we're done, return the results
         if self.all_done:
             return self.results
@@ -801,9 +801,9 @@ class NetACLInfo(Commando):
     :param skip_disabled:
         Whether to include interface names without any information. (Default:
         ``True``)
-    """
+    """  # noqa: D205
 
-    def __init__(self, **args):
+    def __init__(self, **args):  # noqa: D107
         try:
             import pyparsing as pp  # noqa: F401
         except ImportError as err:
@@ -830,7 +830,7 @@ class NetACLInfo(Commando):
     def to_cisco(self, dev, commands=None, extra=None):
         """Generate the "show me all interface information" command we pass to
         IOS devices.
-        """
+        """  # noqa: D205
         if dev.is_cisco_asa():
             return [
                 "show running-config | include ^(interface | ip address | nameif | description |access-group|!)",
@@ -860,7 +860,7 @@ class NetACLInfo(Commando):
         + You only get the "grep" ("include" equivalent) when using "show
           run".
         + The regex must be quoted.
-        """
+        """  # noqa: D205
         return [
             'show running-config | grep "^(interface | ip address | ip access-group | description|!)"',
         ]
@@ -896,7 +896,7 @@ class NetACLInfo(Commando):
     def to_juniper(self, dev, commands=None, extra=None):
         """Generates an etree.Element object suitable for use with
         JunoScript.
-        """
+        """  # noqa: D401, D205
         cmd = Element("get-configuration", database="committed", inherit="inherit")
 
         SubElement(SubElement(cmd, "configuration"), "interfaces")
@@ -1002,7 +1002,7 @@ def _parse_ios_interfaces(
 
     :param skip_disabled:
         Whether to skip disabled interfaces. (Default: ``True``)
-    """
+    """  # noqa: D401
     import pyparsing as pp
 
     # Setup
@@ -1172,19 +1172,19 @@ def _cleanup_interface_results(results, skip_disabled=True):
 def _make_ipy(nets):
     """Given a list of 2-tuples of (address, netmask), returns a list of
     IP address objects.
-    """
+    """  # noqa: D205
     return [IP(addr) for addr, mask in nets]
 
 
 def _make_cidrs(nets):
     """Given a list of 2-tuples of (address, netmask), returns a list CIDR
     blocks.
-    """
+    """  # noqa: D205
     return [IP(addr).make_net(mask) for addr, mask in nets]
 
 
 def _dump_interfaces(idict):
-    """Prints a dict of parsed interface results info for use in debugging."""
+    """Prints a dict of parsed interface results info for use in debugging."""  # noqa: D401
     for name, info in idict.items():
         print(">>>", name)
         print(

--- a/trigger/conf/__init__.py
+++ b/trigger/conf/__init__.py
@@ -42,7 +42,7 @@ __all__ = ("BaseSettings", "DummySettings", "Settings", "settings")
 class DummySettings:
     """Emulates settings and returns empty strings on attribute gets."""
 
-    def __getattribute__(self, name):
+    def __getattribute__(self, name):  # noqa: D105
         return ""
 
 
@@ -51,14 +51,14 @@ class DummySettings:
 class BaseSettings:
     """Common logic for settings whether set by a module or by the user."""
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name, value):  # noqa: D105
         object.__setattr__(self, name, value)
 
 
 class Settings(BaseSettings):
     """Trigger settings loaded from a settings module."""
 
-    def __init__(self, settings_module):
+    def __init__(self, settings_module):  # noqa: D107
         # Update this dict from global settings (but only for ALL_CAPS settings)
         for setting in dir(global_settings):
             if setting == setting.upper():

--- a/trigger/conf/global_settings.py
+++ b/trigger/conf/global_settings.py
@@ -573,7 +573,7 @@ def _get_tftp_source(dev=None, no_vip=True):  # False): #True):
 
     :param dev:
         A `~trigger.netdevices.NetDevice` object
-    """
+    """  # noqa: D205
     import socket
 
     from trigger.conf import settings

--- a/trigger/contrib/__init__.py
+++ b/trigger/contrib/__init__.py
@@ -3,4 +3,4 @@
 
 Extra, optional tools that solve common problems, extend, or modify core
 functionality.
-"""
+"""  # noqa: D205

--- a/trigger/contrib/commando/__init__.py
+++ b/trigger/contrib/commando/__init__.py
@@ -11,7 +11,7 @@ This differs from `~trigger.cmds.Commando` in that:
 + The ``.run()`` method returns a ``twisted.internet.defer.Deferred`` object.
 + Results/errors are stored in a list instead of a dict.
 + Each result object is meant to be easily serialized (e.g. to JSON).
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum, Mike Biancaniello"
 __maintainer__ = "Jathan McCollum"
@@ -48,11 +48,11 @@ class CommandoApplication(Commando):
     running (e.g. twistd or an application server).
 
     Stores results as a list of dictionaries ideal for serializing to JSON.
-    """
+    """  # noqa: D205
 
     timeout = 5
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # noqa: D107
         self.all_done = False
         self.results = []
         self.errors = []
@@ -104,7 +104,7 @@ class CommandoApplication(Commando):
 
         Should do somethign meaningful with the errors, but for now just stores
         it as it would a result.
-        """
+        """  # noqa: D401
         devname = str(device)
         log.msg(f"Storing error for {devname}: {error}")
 
@@ -131,7 +131,7 @@ class CommandoApplication(Commando):
 
         :param results:
             The results to store. Anything you want really.
-        """
+        """  # noqa: D401
         devname = str(device)
         log.msg(f"Storing results for {devname!r}: {results!r}")
 
@@ -176,7 +176,7 @@ class CommandoApplication(Commando):
         log.msg(f"MY  ERRORS ARE: {self.errors!r}")
         self.all_done = True
 
-    def run(self):
+    def run(self):  # noqa: D102
         log.msg(".run() called")
         self._add_worker()
         self._start()
@@ -191,7 +191,7 @@ class CommandoApplication(Commando):
     def monitor_result(self, result, reactor):
         """Loop periodically or until the factory stops to monitor the results
         and return them.
-        """
+        """  # noqa: D205
         log.msg(">>>>> monitor_result() called")
         log.msg(f">>>>> self.all_done = {self.all_done}")
         if self.all_done:

--- a/trigger/contrib/commando/plugins/__init__.py
+++ b/trigger/contrib/commando/plugins/__init__.py
@@ -3,4 +3,4 @@
 
 This package provides facilities for running commands on devices using the CLI.
 Plugins for the Commando API built around Trigger.
-"""
+"""  # noqa: D205

--- a/trigger/contrib/commando/plugins/config_device.py
+++ b/trigger/contrib/commando/plugins/config_device.py
@@ -33,7 +33,7 @@ class ConfigDevice(CommandoApplication):
     tftp_host = settings.TFTP_HOST
     tftp_ip = gethostbyname(tftp_host)
 
-    def __init__(
+    def __init__(  # noqa: D107
         self,
         action="replace",
         files=None,
@@ -66,7 +66,7 @@ class ConfigDevice(CommandoApplication):
     ## The dev is passed to allow for creating different
     ## commands based on model and version!!
 
-    def to_cisco(self, dev, commands=None, extra=None):
+    def to_cisco(self, dev, commands=None, extra=None):  # noqa: D102
         cmds = []
         files = self.files
         for fn in files:
@@ -77,7 +77,7 @@ class ConfigDevice(CommandoApplication):
 
     to_arista = to_cisco
 
-    def to_brocade(self, dev, commands=None, extra=None):
+    def to_brocade(self, dev, commands=None, extra=None):  # noqa: D102
         cmds = []
         action = self.action
         files = self.files
@@ -92,7 +92,7 @@ class ConfigDevice(CommandoApplication):
         cmds.append("copy running-config startup-config")
         return cmds
 
-    def to_dell(self, dev, commands=None, extra=None):
+    def to_dell(self, dev, commands=None, extra=None):  # noqa: D102
         cmds = []
         files = self.files
         if dev.make != "POWERCONNECT":
@@ -104,12 +104,12 @@ class ConfigDevice(CommandoApplication):
         cmds.append("copy running-config startup-config")
         return cmds
 
-    def to_a10(self, dev, commands=None, extra=None):
+    def to_a10(self, dev, commands=None, extra=None):  # noqa: D102
         cmds = []
         log.msg(f"Device Type ({dev.vendor}) not supported")
         return cmds
 
-    def to_juniper(self, dev, commands=None, extra=None):
+    def to_juniper(self, dev, commands=None, extra=None):  # noqa: D102
         if commands is None:
             commands = []
         cmds = [Element("lock-configuration")]

--- a/trigger/contrib/commando/plugins/gather_info.py
+++ b/trigger/contrib/commando/plugins/gather_info.py
@@ -69,7 +69,7 @@ def xmlrpc_gather_info(*args, **kwargs):
 class GatherInfo(Commando):
     """Extension of Commando class for generating the proper commands to
     run per-platform.
-    """
+    """  # noqa: D205
 
     vendors: ClassVar[list[str]] = ["cisco"]
     ios_shver_parse = re.compile(
@@ -106,7 +106,7 @@ class GatherInfo(Commando):
     def to_cisco(self, device, commands=None, extra=None):
         """We want different information depending on whether the device
         is a switch, router, or firewall.
-        """
+        """  # noqa: D205
         if device.is_cisco_asa():
             return [
                 "show version",
@@ -144,7 +144,7 @@ class GatherInfo(Commando):
 
         Will add keys to each host's dictionary in results for hostname,
         serial number, software image, and more.
-        """
+        """  # noqa: D401
         commands_ran = self.generate(device)
         results_dict = {
             "commands_ran": self.map_results(commands_ran, results),

--- a/trigger/contrib/commando/plugins/show_clock.py
+++ b/trigger/contrib/commando/plugins/show_clock.py
@@ -23,16 +23,16 @@ def xmlrpc_show_clock(*args, **kwargs):
 class ShowClock(CommandoApplication):
     """Commando application for retrieving device clock information."""
 
-    def to_cisco(self, dev, commands=None, extra=None):
+    def to_cisco(self, dev, commands=None, extra=None):  # noqa: D102
         return ["show clock"]
 
     to_brocade = to_cisco
 
-    def to_arista(self, dev, commands=None, extra=None):
+    def to_arista(self, dev, commands=None, extra=None):  # noqa: D102
         return ["show clock", "show uptime"]
 
     def to_juniper(self, dev, commands=None, extra=None):
-        """Generates an etree.Element object suitable for use with JunoScript."""
+        """Generates an etree.Element object suitable for use with JunoScript."""  # noqa: D401
         cmd = Element("get-system-uptime-information")
         self.commands = [cmd]
         return self.commands
@@ -53,7 +53,7 @@ class ShowClock(CommandoApplication):
     def from_brocade(self, data, device, commands=None):
         """Parse Brocade time. Brocade switches and routers behave
         differently...
-        """
+        """  # noqa: D205
         if device.is_router():
             # => '16:42:04 GMT+00 Thu Jun 28 2012\r\n'
             fmt = "%H:%M:%S GMT+00 %a %b %d %Y\r\n"
@@ -110,7 +110,7 @@ class ShowClock(CommandoApplication):
     def _parse_datetime(self, datestr, fmt):
         """Given a date string and a format, try to parse and return
         datetime.datetime object.
-        """
+        """  # noqa: D205
         try:
             d = datetime.datetime.strptime(datestr, fmt)
             return d.isoformat()

--- a/trigger/contrib/docommand/__init__.py
+++ b/trigger/contrib/docommand/__init__.py
@@ -4,7 +4,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This package provides facilities for running commands on devices using the CLI.
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum, Mike Biancianello"
 __maintainer__ = "Jathan McCollum"
@@ -41,7 +41,7 @@ class DoCommandBase(Commando):
 
     description = "Insert description here."
 
-    def errback(self, failure, device):
+    def errback(self, failure, device):  # noqa: D102
         failure = super().errback(failure, device)
         print(f"{device} - Error: {failure.value}")
         return failure
@@ -88,7 +88,7 @@ class CommandRunner(DoCommandBase):
 
         :param timeout:
             Timeout in seconds
-        """
+        """  # noqa: D205
         if files is None:
             files = []
         if commands is None:
@@ -110,7 +110,7 @@ class CommandRunner(DoCommandBase):
         """Reads in file contents and adds to self.commands list.
 
         This is done to prevent having to read the list of cmds multiple times.
-        """
+        """  # noqa: D401
         for fname in self.files:
             with Path(fname).open() as fr:
                 lines = fr.readlines()
@@ -143,7 +143,7 @@ class CommandRunner(DoCommandBase):
     def __children_with_namespace(self, ns):
         return lambda elt, tag: elt.findall("./" + ns + tag)
 
-    def from_juniper(self, data, device, commands=None):
+    def from_juniper(self, data, device, commands=None):  # noqa: D102
         # If we've set foce_cli, use from_base() instead
         if self.force_cli:
             return self.from_base(data, device, commands)
@@ -235,7 +235,7 @@ class ConfigLoader(Commando):
 
         :param debug:
             Whether to display debug information
-        """
+        """  # noqa: D205
         if files is None:
             files = []
         if commands is None:
@@ -262,7 +262,7 @@ class ConfigLoader(Commando):
             body = SubElement(lc, "configuration-text")
             if self.debug:
                 print("fname: " + fname)
-            body.text = file(fname).read()
+            body.text = file(fname).read()  # noqa: F405
             cmds.append(lc)
         if len(commands) > 0:
             lc = Element("load-configuration", action="replace", format="text")

--- a/trigger/contrib/xmlrpc/__init__.py
+++ b/trigger/contrib/xmlrpc/__init__.py
@@ -2,4 +2,4 @@
 ~~~~~~~~~~~~~~~~~~~~~~
 
 XMLRPC Server for Trigger with SSH manhole service.
-"""
+"""  # noqa: D205

--- a/trigger/contrib/xmlrpc/server.py
+++ b/trigger/contrib/xmlrpc/server.py
@@ -31,7 +31,7 @@ if os.getenv("DEBUG"):
 class TriggerXMLRPCServer(xmlrpc.XMLRPC):
     """Twisted XMLRPC server front-end for Commando."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # noqa: D107
         xmlrpc.XMLRPC.__init__(self, *args, **kwargs)
         self.allowNone = True
         self.useDateTime = True
@@ -156,7 +156,7 @@ class TriggerXMLRPCServer(xmlrpc.XMLRPC):
         # Bind the dummy shell method to TriggerXMLRPCServer as 'xmlrpc_' + task_name
         setattr(TriggerXMLRPCServer, "xmlrpc_" + task_name, dummy)
 
-    def xmlrpc_list_subhandlers(self):
+    def xmlrpc_list_subhandlers(self):  # noqa: D102
         return list(self.subHandlers)
 
     def xmlrpc_execute_commands(self, args, kwargs):
@@ -165,7 +165,7 @@ class TriggerXMLRPCServer(xmlrpc.XMLRPC):
         return c.run()
 
     def xmlrpc_add(self, x, y):
-        """Adds x and y."""
+        """Adds x and y."""  # noqa: D401
         return x + y
 
     def xmlrpc_fault(self):
@@ -175,7 +175,7 @@ class TriggerXMLRPCServer(xmlrpc.XMLRPC):
     def _ebRender(self, failure):
         """Custom exception rendering.
         Ref: https://netzguerilla.net/iro/dev/_modules/iro/view/xmlrpc.html.
-        """
+        """  # noqa: D401, D205
         if isinstance(failure.value, Exception):
             msg = f"""{failure.type.__name__}: {failure.value.args[0]}"""
             return xmlrpc.Fault(400, msg)

--- a/trigger/exceptions.py
+++ b/trigger/exceptions.py
@@ -1,6 +1,6 @@
 """All custom exceptions used by Trigger. Where possible built-in exceptions are
 used, but sometimes we need more descriptive errors.
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum"
 __maintainer__ = "Jathan McCollum"
@@ -32,14 +32,14 @@ class ACLError(TriggerError):
 class ParseError(ACLError):
     """Raised when there is an error parsing/normalizing an ACL that tries to tell
     you where it failed.
-    """
+    """  # noqa: D205
 
-    def __init__(self, reason, line=None, column=None):
+    def __init__(self, reason, line=None, column=None):  # noqa: D107
         self.reason = reason
         self.line = line
         self.column = column
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         s = self.reason
         if self.line is not None and self.line > 1:
             s += " at line %d" % self.line  # noqa: UP031
@@ -50,13 +50,13 @@ class ParseError(ACLError):
 class BadTermName(ACLError):
     """Raised when an invalid name is assigned to a `~trigger.acl.parser.Term`
     object.
-    """
+    """  # noqa: D205
 
 
 class MissingTermName(ACLError):
     """Raised when a an un-named Term is output to a format that requires Terms to
     be named (e.g. Juniper).
-    """
+    """  # noqa: D205
 
 
 class VendorSupportLacking(ACLError):
@@ -84,7 +84,7 @@ class ActionError(ACLError):
 class UnknownActionName(ActionError):
     """Raised when an action assigned to a ~trigger.acl.parser.Term` object is
     unknown.
-    """
+    """  # noqa: D205
 
 
 class BadRoutingInstanceName(ActionError):
@@ -115,13 +115,13 @@ class BadPolicerName(ActionError):
 class MatchError(ACLError):
     """A base exception for all errors related to Term
     `~trigger.acl.parser.Matches` objects.
-    """
+    """  # noqa: D205
 
 
 class BadMatchArgRange(MatchError):
     """Raised when a match condition argument does not fall within a specified
     range.
-    """
+    """  # noqa: D205
 
 
 class UnknownMatchType(MatchError):
@@ -207,7 +207,7 @@ class ConnectionFailure(TwisterError):
 class SSHConnectionLost(TwisterError):
     """Raised when an SSH connection is lost for any reason."""
 
-    def __init__(self, code, desc):
+    def __init__(self, code, desc):  # noqa: D107
         self.code = code
         TwisterError.__init__(self, desc)
 
@@ -219,7 +219,7 @@ class CommandTimeout(TwisterError):
 class CommandFailure(TwisterError):
     """Raised when a command fails to execute, such as when it results in an
     error.
-    """
+    """  # noqa: D205
 
 
 class IoslikeCommandFailure(CommandFailure):
@@ -233,10 +233,10 @@ class NetscalerCommandFailure(CommandFailure):
 class JunoscriptCommandFailure(CommandFailure):
     """Raised when a Junoscript command fails on a Juniper device."""
 
-    def __init__(self, tag):
+    def __init__(self, tag):  # noqa: D107
         self.tag = tag
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         s = "JunOS XML command failure:\n"
         ns = "{http://xml.juniper.net/xnm/1.1/xnm}"
         for e in self.tag.findall(f".//{ns}error"):

--- a/trigger/gorc.py
+++ b/trigger/gorc.py
@@ -39,7 +39,7 @@ object's method of the same name) to override anything specified in a user's
     foo1-abc#exit
     >>>
 
-"""
+"""  # noqa: D205
 
 # Imports
 import configparser
@@ -95,7 +95,7 @@ def filter_commands(cmds, allowed_commands=None):
 
     :returns:
         Filtered list of commands
-    """
+    """  # noqa: D401
     if allowed_commands is None:
         allowed_commands = settings.GORC_ALLOWED_COMMANDS
     ret = []
@@ -152,7 +152,7 @@ def get_init_commands(vendor):
 
     :returns:
         list of commands
-    """
+    """  # noqa: D205
     config = read_config()
     return parse_commands(vendor, config=config)
 

--- a/trigger/netdevices/__init__.py
+++ b/trigger/netdevices/__init__.py
@@ -17,7 +17,7 @@ Example::
     >>> dev.bounce.next_ok('green')
     datetime.datetime(2010, 4, 9, 9, 0, tzinfo=<UTC>)
 
-"""
+"""  # noqa: D205
 
 # Imports
 import copy
@@ -76,7 +76,7 @@ def _populate(netdevices, data_source, production_only, with_acls):
 
     Abstracted from within NetDevices to prevent accidental repopulation of NetDevice
     objects.
-    """
+    """  # noqa: D401
     loader, device_data = _munge_source_data(data_source=data_source)
     netdevices.set_loader(loader)
 
@@ -176,7 +176,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
     `~trigger.netdevice.NetDevices` to do this for you.
     """
 
-    def __init__(self, data=None, with_acls=None):
+    def __init__(self, data=None, with_acls=None):  # noqa: D107
         # Here comes all of the bare minimum set of attributes a NetDevice
         # object needs for basic functionality within the existing suite.
 
@@ -318,7 +318,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
     def _set_requires_async_pty(self):
         """Set whether a device requires an async pty (see:
         `~trigger.twister.TriggerSSHAsyncPtyChannel`).
-        """
+        """  # noqa: D205
         RULES = (
             self.vendor in ("a10", "arista", "aruba", "cisco", "cumulus", "force10"),
             self.is_brocade_vdx(),
@@ -336,7 +336,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
     def _set_startup_commands(self):
         """Set the commands to run at startup. For now they are just ones to
         disable pagination.
-        """
+        """  # noqa: D205
 
         def get_vendor_name():
             """Return the vendor name for startup commands lookup."""
@@ -383,7 +383,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
     def _juniper_commit(self, fields=settings.JUNIPER_FULL_COMMIT_FIELDS):
         """Return proper ``commit-configuration`` element for a Juniper
         device.
-        """
+        """  # noqa: D205
         default = [JUNIPER_COMMIT]
         if not fields:
             return default
@@ -425,10 +425,10 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
         self.implicit_acls = acls_dict["implicit"]
         self.acls = acls_dict["all"]
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         return self.nodeName
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"<NetDevice: {self.nodeName}>"
 
     def __eq__(self, other):
@@ -437,42 +437,42 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
             return NotImplemented
         return self.nodeName == other.nodeName
 
-    def __ne__(self, other):
+    def __ne__(self, other):  # noqa: D105
         result = self.__eq__(other)
         if result is NotImplemented:
             return NotImplemented
         return not result
 
-    def __lt__(self, other):
+    def __lt__(self, other):  # noqa: D105
         if not isinstance(other, NetDevice):
             return NotImplemented
         return self.nodeName < other.nodeName
 
-    def __le__(self, other):
+    def __le__(self, other):  # noqa: D105
         if not isinstance(other, NetDevice):
             return NotImplemented
         return self.nodeName <= other.nodeName
 
-    def __gt__(self, other):
+    def __gt__(self, other):  # noqa: D105
         if not isinstance(other, NetDevice):
             return NotImplemented
         return self.nodeName > other.nodeName
 
-    def __ge__(self, other):
+    def __ge__(self, other):  # noqa: D105
         if not isinstance(other, NetDevice):
             return NotImplemented
         return self.nodeName >= other.nodeName
 
     @property
-    def bounce(self):
+    def bounce(self):  # noqa: D102
         return changemgmt.bounce(self)
 
     @property
-    def shortName(self):
+    def shortName(self):  # noqa: D102
         return self.nodeName.split(".", 1)[0]
 
     @property
-    def os(self):  # noqa: F811 - property name intentionally shadows os module
+    def os(self):  # noqa: F811, D102
         vendor_mapping = settings.TEXTFSM_VENDOR_MAPPINGS
         try:
             oss = vendor_mapping[self.vendor]
@@ -549,14 +549,14 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
 
         self._connected = False
 
-    def __enter__(self):
+    def __enter__(self):  # noqa: D105
         self.open()
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):  # noqa: D105
         self.close()
 
-    def get_results(self):
+    def get_results(self):  # noqa: D102
         self._results = []
         while len(self._results) != len(self.commands):
             pass
@@ -659,7 +659,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
         return d
 
     @property
-    def connected(self):
+    def connected(self):  # noqa: D102
         return self._connected
 
     def allowable(self, action, when=None):
@@ -686,7 +686,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
 
         :param when:
             A datetime object.
-        """
+        """  # noqa: D205
         assert action == "load-acl"  # noqa: S101
         return self.bounce.next_ok(changemgmt.BounceStatus("green"), when)
 
@@ -808,7 +808,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
         if so do I even have SSH?
 
         :param method: One of ('pty', 'async')
-        """
+        """  # noqa: D205
         METHOD_MAP = {
             "pty": settings.SSH_PTY_DISABLED,
             "async": settings.SSH_ASYNC_DISABLED,
@@ -831,7 +831,7 @@ class NetDevice:  # noqa: PLW1641 - mutable object, intentionally unhashable
         return network.ping(self.nodeName)
 
     def dump(self):
-        """Prints details for a device."""
+        """Prints details for a device."""  # noqa: D401
         dev = self
         # Python 3: print is a function, not a statement
         print()
@@ -875,7 +875,7 @@ class Vendor:
         """:param manufacturer:
         The literal or "internal" name for a vendor that is to be mapped to
         its canonical name.
-        """
+        """  # noqa: D205
         if manufacturer is None:
             msg = "You must specify a `manufacturer` name"
             raise SyntaxError(msg)
@@ -902,7 +902,7 @@ class Vendor:
     def _get_prompt_pattern(self, vendor, prompt_patterns=None):
         """Map the vendor name to the appropriate ``prompt_pattern`` defined in
         :setting:`PROMPT_PATTERNS`.
-        """
+        """  # noqa: D205
         if prompt_patterns is None:
             prompt_patterns = settings.PROMPT_PATTERNS
 
@@ -923,22 +923,22 @@ class Vendor:
         """Return the normalized name for the vendor."""
         return self.name.replace(" ", "_").lower()
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105
         return self.name
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"<{self.__class__.__name__}: {self.title}>"
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # noqa: D105
         return self.name.__eq__(Vendor(str(other)).name)
 
-    def __contains__(self, other):
+    def __contains__(self, other):  # noqa: D105
         return self.name.__contains__(Vendor(str(other)).name)
 
-    def __hash__(self):
+    def __hash__(self):  # noqa: D105
         return hash(self.name)
 
-    def lower(self):
+    def lower(self):  # noqa: D102
         return self.normalized
 
 
@@ -953,7 +953,7 @@ def vendor_factory(vendor_name):
 
     :param vendor_name:
         The vendor's full manufacturer name (e.g. 'CISCO SYSTEMS')
-    """
+    """  # noqa: D205
     return _vendor_registry.setdefault(vendor_name, Vendor(vendor_name))
 
 
@@ -971,7 +971,7 @@ class NetDevices(MutableMapping):
       2. hot spares with the same ``nodeName``.
 
     You may override this by passing ``production_only=False``.
-    """
+    """  # noqa: D205
 
     _Singleton = None
 
@@ -994,7 +994,7 @@ class NetDevices(MutableMapping):
               File "<stdin>", line 1, in <module>
             TypeError: unbound method match() must be called with _actual
             instance as first argument (got str instance instead)
-        """
+        """  # noqa: D205
 
         def __init__(self, production_only=True, with_acls=None):
             self.loader = None
@@ -1058,7 +1058,7 @@ class NetDevices(MutableMapping):
 
             :param string key: Hostname prefix to find.
             :returns: NetDevice object
-            """
+            """  # noqa: D205
             key = key.lower()
 
             # Try to use the loader plugin first.
@@ -1080,7 +1080,7 @@ class NetDevices(MutableMapping):
 
             This method can be overloaded in NetDevices loader plugins to
             customize the behavior as dictated by the plugin.
-            """
+            """  # noqa: D401
             if hasattr(self.loader, "all"):
                 return self.loader.all()
             # Python 3: dict.values() returns a view, convert to list
@@ -1110,7 +1110,7 @@ class NetDevices(MutableMapping):
             :param string token: Token to search match on in @field
             :param string field: The field to match on when searching
             :returns: List of NetDevice objects
-            """
+            """  # noqa: D401, D205
             # We could actually just make this call match() to make this
             # case-insensitive as well. But we won't yet because of possible
             # implications in outside dependencies.
@@ -1140,7 +1140,7 @@ class NetDevices(MutableMapping):
                 >>> mydevices = nd(oncallname='data center', model='fcslb')
 
             :returns: List of NetDevice objects
-            """
+            """  # noqa: D205
             skip_loader = kwargs.pop("skip_loader", False)
             if skip_loader:
                 log.msg("Skipping loader.match()")
@@ -1161,7 +1161,7 @@ class NetDevices(MutableMapping):
                 self._all_field_names = all_field_names
 
             def map_attr(attr):
-                """Helper function for lower-to-regular attribute mapping."""
+                """Helper function for lower-to-regular attribute mapping."""  # noqa: D401
                 return self._all_field_names[attr.lower()]
 
             # Use list comp. to keep filtering out the devices.
@@ -1178,19 +1178,19 @@ class NetDevices(MutableMapping):
             """Returns a list of NetDevice objects with deviceType matching type.
 
             Known deviceTypes: ['FIREWALL', 'ROUTER', 'SWITCH']
-            """
+            """  # noqa: D401
             return [x for x in self.values() if x.deviceType == devtype]
 
         def list_switches(self):
-            """Returns a list of NetDevice objects with deviceType of SWITCH."""
+            """Returns a list of NetDevice objects with deviceType of SWITCH."""  # noqa: D401
             return self.get_devices_by_type("SWITCH")
 
         def list_routers(self):
-            """Returns a list of NetDevice objects with deviceType of ROUTER."""
+            """Returns a list of NetDevice objects with deviceType of ROUTER."""  # noqa: D401
             return self.get_devices_by_type("ROUTER")
 
         def list_firewalls(self):
-            """Returns a list of NetDevice objects with deviceType of FIREWALL."""
+            """Returns a list of NetDevice objects with deviceType of FIREWALL."""  # noqa: D401
             return self.get_devices_by_type("FIREWALL")
 
     def __init__(self, production_only=True, with_acls=None):
@@ -1200,7 +1200,7 @@ class NetDevices(MutableMapping):
         :param with_acls:
             Whether to load ACL associations (requires Redis). Defaults to whatever
             is specified in settings.WITH_ACLS
-        """
+        """  # noqa: D205
         if with_acls is None:
             with_acls = settings.WITH_ACLS
         classobj = self.__class__
@@ -1210,26 +1210,26 @@ class NetDevices(MutableMapping):
                 with_acls=with_acls,
             )
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr):  # noqa: D105
         return getattr(self.__class__._Singleton, attr)
 
-    def __setattr__(self, attr, value):
+    def __setattr__(self, attr, value):  # noqa: D105
         return setattr(self.__class__._Singleton, attr, value)
 
     # MutableMapping abstract methods - delegate to singleton
-    def __getitem__(self, key):
+    def __getitem__(self, key):  # noqa: D105
         return self.__class__._Singleton[key]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key, value):  # noqa: D105
         self.__class__._Singleton._dict[key] = value
 
-    def __delitem__(self, key):
+    def __delitem__(self, key):  # noqa: D105
         del self.__class__._Singleton._dict[key]
 
-    def __iter__(self):
+    def __iter__(self):  # noqa: D105
         return iter(self.__class__._Singleton._dict)
 
-    def __len__(self):
+    def __len__(self):  # noqa: D105
         return len(self.__class__._Singleton._dict)
 
     def reload(self, **kwargs):

--- a/trigger/netdevices/loader.py
+++ b/trigger/netdevices/loader.py
@@ -17,7 +17,7 @@ specifies whether the loader can be used with this Python installation. Each
 loader is responsible for setting this when it is initialized.
 
 This code is based on Django's template loader code: http://bit.ly/WWOLU3
-"""
+"""  # noqa: D205
 
 from collections import namedtuple
 
@@ -37,21 +37,21 @@ class BaseLoader:
 
     is_usable = False
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # noqa: D107
         pass
 
-    def __call__(self, data_source, **kwargs):
+    def __call__(self, data_source, **kwargs):  # noqa: D102
         return self.load_data(data_source, **kwargs)
 
-    def load_data(self, data_source, **kwargs):
+    def load_data(self, data_source, **kwargs):  # noqa: D102
         return self.load_data_source(data_source, **kwargs)
 
     def load_data_source(self, data_source, **kwargs):
-        """Returns an iterable of key/value pairs for the given ``data_source``."""
+        """Returns an iterable of key/value pairs for the given ``data_source``."""  # noqa: D401
         raise NotImplementedError
 
     def reset(self):
-        """Resets any state maintained by the loader instance."""
+        """Resets any state maintained by the loader instance."""  # noqa: D401
 
 
 # Functions
@@ -70,7 +70,7 @@ def find_data_loader(loader):
     :param loader:
         A string represnting the Python path to a Loader object, or list/tuple
         of loader path and args to pass to the Loader.
-    """
+    """  # noqa: D205
     if isinstance(loader, (tuple, list)):
         loader, args = loader[0], loader[1:]
     else:

--- a/trigger/netdevices/loaders/__init__.py
+++ b/trigger/netdevices/loaders/__init__.py
@@ -2,4 +2,4 @@
 `~trigger.netdevices.NetDevice` objects.
 
 By default, Trigger provides filesystem-based data loaders.
-"""
+"""  # noqa: D205

--- a/trigger/netdevices/loaders/filesystem.py
+++ b/trigger/netdevices/loaders/filesystem.py
@@ -1,6 +1,6 @@
 """Built-in Loader objects for loading `~trigger.netdevices.NetDevice` metadata
 from the filesystem.
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum"
 __maintainer__ = "Jathan McCollum"
@@ -39,13 +39,13 @@ class JSONLoader(BaseLoader):
 
     is_usable = True
 
-    def get_data(self, data_source):
+    def get_data(self, data_source):  # noqa: D102
         with Path(data_source).open() as contents:
             # TODO (jathan): Can we somehow return an generator like the other
             # _parse methods? Maybe using JSONDecoder?
             return json.load(contents)
 
-    def load_data_source(self, data_source, **kwargs):
+    def load_data_source(self, data_source, **kwargs):  # noqa: D102
         try:
             return self.get_data(data_source)
         except Exception as err:
@@ -62,7 +62,7 @@ class XMLLoader(BaseLoader):
 
     is_usable = True
 
-    def get_data(self, data_source):
+    def get_data(self, data_source):  # noqa: D102
         # Parsing the complete file into a tree once and extracting outthe
         # device nodes is faster than using iterparse(). Curses!!
         xml = ET.parse(data_source).findall("device")  # noqa: S314 - trusted local data
@@ -71,7 +71,7 @@ class XMLLoader(BaseLoader):
         # Python 3.9+: getchildren() removed, use list(node) instead
         return (((e.tag, e.text) for e in list(node)) for node in xml)
 
-    def load_data_source(self, data_source, **kwargs):
+    def load_data_source(self, data_source, **kwargs):  # noqa: D102
         try:
             return self.get_data(data_source)
         except Exception as err:
@@ -88,10 +88,10 @@ class RancidLoader(BaseLoader):
 
     is_usable = True
 
-    def get_data(self, data_source, recurse_subdirs=None):
+    def get_data(self, data_source, recurse_subdirs=None):  # noqa: D102
         return rancid.parse_rancid_data(data_source, recurse_subdirs=recurse_subdirs)
 
-    def load_data_source(self, data_source, **kwargs):
+    def load_data_source(self, data_source, **kwargs):  # noqa: D102
         # We want to make sure that we've set this variable
         recurse_subdirs = kwargs.get("recurse_subdirs", settings.RANCID_RECURSE_SUBDIRS)
         try:
@@ -109,7 +109,7 @@ class SQLiteLoader(BaseLoader):
 
     is_usable = SQLITE_AVAILABLE
 
-    def get_data(self, data_source, table_name="netdevices"):
+    def get_data(self, data_source, table_name="netdevices"):  # noqa: D102
         connection = sqlite3.connect(data_source)
         cursor = connection.cursor()
 
@@ -127,7 +127,7 @@ class SQLiteLoader(BaseLoader):
         # lists containing 2-tuples (key, value).
         return (itertools.izip(columns, row) for row in devrows)
 
-    def load_data_source(self, data_source, **kwargs):
+    def load_data_source(self, data_source, **kwargs):  # noqa: D102
         table_name = kwargs.get("table_name", "netdevices")
         try:
             return self.get_data(data_source, table_name)
@@ -153,11 +153,11 @@ class CSVLoader(BaseLoader):
 
     is_usable = True
 
-    def get_data(self, data_source):
+    def get_data(self, data_source):  # noqa: D102
         root_dir, filename = os.path.split(data_source)
         return rancid.parse_rancid_file(root_dir, filename, delimiter=",")
 
-    def load_data_source(self, data_source, **kwargs):
+    def load_data_source(self, data_source, **kwargs):  # noqa: D102
         try:
             return self.get_data(data_source)
         except Exception as err:

--- a/trigger/netdevices/loaders/mongodb.py
+++ b/trigger/netdevices/loaders/mongodb.py
@@ -21,12 +21,12 @@ class MongoDBLoader(BaseLoader):
 
     is_usable = PYMONGO_AVAILABLE
 
-    def get_data(self, data_source, host, port, database, table_name):
+    def get_data(self, data_source, host, port, database, table_name):  # noqa: D102
         client = MongoClient(host, port)
         collection = client[database][table_name]
         return list(collection.find())
 
-    def load_data_source(self, data_source, **kwargs):
+    def load_data_source(self, data_source, **kwargs):  # noqa: D102
         host = kwargs.get("hostname")
         port = kwargs.get("port")
         database = kwargs.get("database")

--- a/trigger/netscreen.py
+++ b/trigger/netscreen.py
@@ -1,7 +1,7 @@
 """Parses and manipulates firewall policy for Juniper NetScreen firewall devices.
 Broken apart from acl.parser because the approaches are vastly different from each
 other.
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum, Mark Thomas"
 __maintainer__ = "Jathan McCollum"
@@ -44,7 +44,7 @@ __all__ = (
 class NetScreen:
     """Parses and generates NetScreen firewall policy."""
 
-    def __init__(self):
+    def __init__(self):  # noqa: D107
         self.service_book = NSServiceBook()
         self.address_book = NSAddressBook()
         self.interfaces = []
@@ -200,7 +200,7 @@ class NetScreen:
         )
 
     def concatenate_grp(self, x):
-        """Used by NetScreen class when grouping policy members."""
+        """Used by NetScreen class when grouping policy members."""  # noqa: D401
         ret = {}
         for entry in x:
             for key, val in entry.items():
@@ -211,7 +211,7 @@ class NetScreen:
         return ret
 
     def netmask2cidr(self, iptuple):
-        """Converts dotted-quad netmask to cidr notation."""
+        """Converts dotted-quad netmask to cidr notation."""  # noqa: D401
         if len(iptuple) == 2:  # noqa: PLR2004
             addr, mask = iptuple
             ipstr = addr.strNormal() + "/" + mask.strNormal()
@@ -221,7 +221,7 @@ class NetScreen:
     def handle_raw_netscreen(self, rows):  # noqa: PLR0912, PLR0915
         """The parser will hand it's final output to this function, which decodes
         and puts everything in the right place.
-        """
+        """  # noqa: D401, D205
         for node in rows:
             if isinstance(node, NSAddress):
                 self.address_book.append(node)
@@ -365,14 +365,14 @@ class NetScreen:
             else:
                 raise f"Unknown node type {type(node)!s}"
 
-    def output(self):
+    def output(self):  # noqa: D102
         ret = list(self.address_book.output())
         ret.extend(self.service_book.output())
         for ent in self.policies:
             ret.extend(ent.output())
         return ret
 
-    def output_terms(self):
+    def output_terms(self):  # noqa: D102
         ret = []
         for ent in self.policies:
             ret.extend(ent.output_terms())
@@ -385,7 +385,7 @@ class NetScreen:
 class NSRawGroup:
     """Container for group definitions."""
 
-    def __init__(self, data):
+    def __init__(self, data):  # noqa: D107
         if data[0] == "address" and len(data) == 3:  # noqa: PLR2004
             data.append(None)
         if data[0] == "service" and len(data) == 2:  # noqa: PLR2004
@@ -393,26 +393,26 @@ class NSRawGroup:
 
         self.data = data
 
-    def __iter__(self):
+    def __iter__(self):  # noqa: D105
         return self.data.__iter__()
 
-    def __len__(self):
+    def __len__(self):  # noqa: D105
         return self.data.__len__()
 
 
 class NSGroup(NetScreen):
     """Container for address/service groups."""
 
-    def __init__(self, name=None, group_type="address", zone=None):
+    def __init__(self, name=None, group_type="address", zone=None):  # noqa: D107
         self.nodes = []
         self.name = name
         self.type = group_type
         self.zone = zone
 
-    def append(self, item):
+    def append(self, item):  # noqa: D102
         return getattr(self, "add_" + self.type)(item)
 
-    def add_address(self, addr):
+    def add_address(self, addr):  # noqa: D102
         assert self.type == "address"  # noqa: S101
         if not isinstance(addr, NSAddress):
             msg = "add_address requires NSAddress object"
@@ -427,7 +427,7 @@ class NSGroup(NetScreen):
                 return
         self.nodes.append(addr)
 
-    def add_service(self, svc):
+    def add_service(self, svc):  # noqa: D102
         assert self.type == "service"  # noqa: S101
         if not isinstance(svc, NSService):
             msg = "add_service requires NSService object"
@@ -437,32 +437,32 @@ class NSGroup(NetScreen):
                 return
         self.nodes.append(svc)
 
-    def set_name(self, name):
+    def set_name(self, name):  # noqa: D102
         self.name = name
 
-    def __getitem__(self, key):
+    def __getitem__(self, key):  # noqa: D105
         # allow people to find things in groups via a dict style
         for i in self.nodes:
             if i.name == key:
                 return i
         raise KeyError
 
-    def __iter__(self):
+    def __iter__(self):  # noqa: D105
         return self.nodes.__iter__()
 
-    def output_crap(self):
+    def output_crap(self):  # noqa: D102
         ret = ""
         for i in self.nodes:
             ret += i.output_crap()
         return ret
 
-    def get_real(self):
+    def get_real(self):  # noqa: D102
         ret = []
         for i in self.nodes:
             ret.extend(i.get_real())
         return ret
 
-    def output(self):
+    def output(self):  # noqa: D102
         ret = []
         for i in self.nodes:
             zone = ""
@@ -483,7 +483,7 @@ class NSServiceBook(NetScreen):
         print(service.output())
     """
 
-    def __init__(self, entries=None):
+    def __init__(self, entries=None):  # noqa: D107
         self.entries = entries or []
         if entries:
             self.entries = entries
@@ -521,13 +521,13 @@ class NSServiceBook(NetScreen):
                 ),
             )
 
-    def has_key(self, key):
+    def has_key(self, key):  # noqa: D102
         return any(key == entry.name for entry in self.entries)
 
-    def __iter__(self):
+    def __iter__(self):  # noqa: D105
         return self.entries.__iter__()
 
-    def __getitem__(self, item):
+    def __getitem__(self, item):  # noqa: D105
         for entry in self.entries:
             if item == entry.name:
                 return entry
@@ -535,7 +535,7 @@ class NSServiceBook(NetScreen):
         msg = "%s"
         raise KeyError(msg, item)
 
-    def append(self, item):
+    def append(self, item):  # noqa: D102
         if isinstance(item, NSService):
             return self.entries.append(item)
         if isinstance(item, NSGroup) and item.type == "service":
@@ -546,7 +546,7 @@ class NSServiceBook(NetScreen):
         )
         raise TypeError(msg)
 
-    def output(self):
+    def output(self):  # noqa: D102
         ret = []
         for ent in self.entries:
             ret.extend(ent.output())
@@ -556,11 +556,11 @@ class NSServiceBook(NetScreen):
 class NSAddressBook(NetScreen):
     """Container for address book entries."""
 
-    def __init__(self, name="ANY", zone=None):
+    def __init__(self, name="ANY", zone=None):  # noqa: D107
         self.entries = {}
         self.any = NSAddress(name="ANY")
 
-    def find(self, address, zone):
+    def find(self, address, zone):  # noqa: D102
         if not self.entries.has_key(zone):
             return None
 
@@ -577,7 +577,7 @@ class NSAddressBook(NetScreen):
 
         return None
 
-    def append(self, item):
+    def append(self, item):  # noqa: D102
         if not isinstance(item, NSAddress) and (
             (not isinstance(item, NSGroup)) and item.type != "address"
         ):
@@ -589,7 +589,7 @@ class NSAddressBook(NetScreen):
 
         return self.entries[item.zone].append(item)
 
-    def name2ips(self, name, zone):
+    def name2ips(self, name, zone):  # noqa: D102
         for entry in self.entries:
             if entry.name == name:
                 if isinstance(entry, NSAddress):
@@ -598,7 +598,7 @@ class NSAddressBook(NetScreen):
                     return [ent.addr for ent in entry]
         return None
 
-    def output(self):
+    def output(self):  # noqa: D102
         ret = []
         for addrs in self.entries.values():
             for addr in addrs:
@@ -609,7 +609,7 @@ class NSAddressBook(NetScreen):
 class NSAddress(NetScreen):
     """Container for individual address items."""
 
-    def __init__(self, name=None, zone=None, addr=None, comment=None):
+    def __init__(self, name=None, zone=None, addr=None, comment=None):  # noqa: D107
         self.name = None
         self.zone = None
         self.addr = TIP("0.0.0.0/0")
@@ -623,30 +623,30 @@ class NSAddress(NetScreen):
         if comment:
             self.set_comment(comment)
 
-    def set_address(self, addr):
+    def set_address(self, addr):  # noqa: D102
         try:
             a = TIP(addr)
         except Exception as e:
             raise e
         self.addr = a
 
-    def set_zone(self, zone):
+    def set_zone(self, zone):  # noqa: D102
         self.zone = zone
 
-    def set_name(self, name):
+    def set_name(self, name):  # noqa: D102
         self.name = name
 
-    def set_comment(self, comment):
+    def set_comment(self, comment):  # noqa: D102
         comment = f'"{comment}"'
         self.comment = comment
 
-    def get_real(self):
+    def get_real(self):  # noqa: D102
         return [self.addr]
 
-    def output_crap(self):
+    def output_crap(self):  # noqa: D102
         return f"[(Z:{self.zone}){self.addr.strNormal()}]"
 
-    def output(self):
+    def output(self):  # noqa: D102
         tmpl = 'set address "%s" "%s" %s %s %s'
         output = tmpl % (
             self.zone,
@@ -661,7 +661,7 @@ class NSAddress(NetScreen):
 class NSService(NetScreen):
     """Container for individual service items."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, D107
         self,
         name=None,
         protocol=None,
@@ -678,14 +678,14 @@ class NSService(NetScreen):
         self.predefined = predefined
         self.initialize()
 
-    def initialize(self):
+    def initialize(self):  # noqa: D102
         self.set_name(self.name)
         self.set_protocol(self.protocol)
         self.set_source_port(self.source_port)
         self.set_destination_port(self.destination_port)
         self.set_timeout(self.timeout)
 
-    def __cmp__(self, other):
+    def __cmp__(self, other):  # noqa: D105
         if not isinstance(other, NSService):
             return -1
 
@@ -701,10 +701,10 @@ class NSService(NetScreen):
 
         return 0
 
-    def set_name(self, arg):
+    def set_name(self, arg):  # noqa: D102
         self.name = arg
 
-    def set_source_port(self, ports):
+    def set_source_port(self, ports):  # noqa: D102
         if isinstance(ports, int):
             check_range([ports], 0, 65535)
             self.source_port = (ports, ports)
@@ -715,7 +715,7 @@ class NSService(NetScreen):
             msg = "add_source_port needs int or tuple argument"
             raise TypeError(msg)
 
-    def set_destination_port(self, ports):
+    def set_destination_port(self, ports):  # noqa: D102
         if isinstance(ports, int):
             check_range([ports], 0, 65535)
             self.destination_port = (ports, ports)
@@ -726,16 +726,16 @@ class NSService(NetScreen):
             msg = "add_destination_port needs int or tuple argument"
             raise TypeError(msg)
 
-    def set_timeout(self, timeout):
+    def set_timeout(self, timeout):  # noqa: D102
         self.timeout = timeout
 
-    def set_protocol(self, protocol):
+    def set_protocol(self, protocol):  # noqa: D102
         if isinstance(protocol, (str, int)):
             self.protocol = Protocol(protocol)
         if isinstance(protocol, Protocol):
             self.protocol = protocol
 
-    def output_crap(self):
+    def output_crap(self):  # noqa: D102
         return "[Service: %s (%d-%d):(%d-%d)]" % (  # noqa: UP031
             self.protocol,
             self.source_port[0],
@@ -744,10 +744,10 @@ class NSService(NetScreen):
             self.destination_port[1],
         )
 
-    def get_real(self):
+    def get_real(self):  # noqa: D102
         return [(self.source_port, self.destination_port, self.protocol)]
 
-    def output(self):
+    def output(self):  # noqa: D102
         if self.predefined:
             return []
         ret = 'set service "%s" protocol %s src-port %d-%d dst-port %d-%d' % (  # noqa: UP031
@@ -766,7 +766,7 @@ class NSService(NetScreen):
 class NSRawPolicy:
     """Container for policy definitions."""
 
-    def __init__(self, data, isglobal=0):
+    def __init__(self, data, isglobal=0):  # noqa: D107
         self.isglobal = isglobal
         self.data = {}
 
@@ -778,7 +778,7 @@ class NSRawPolicy:
 class NSPolicy(NetScreen):
     """Container for individual policy definitions."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, D107
         self,
         name=None,
         address_book=None,
@@ -810,7 +810,7 @@ class NSPolicy(NetScreen):
         self.name = name
         self.isglobal = isglobal
 
-    def add_address(self, address, zone, address_book, addresses):
+    def add_address(self, address, zone, address_book, addresses):  # noqa: D102
         addr = TIP(address)
         found = address_book.find(addr, zone)
         if not found:
@@ -824,7 +824,7 @@ class NSPolicy(NetScreen):
             address_book.append(found)
         addresses.append(found)
 
-    def add_source_address(self, address):
+    def add_source_address(self, address):  # noqa: D102
         self.add_address(
             address,
             self.source_zone,
@@ -832,7 +832,7 @@ class NSPolicy(NetScreen):
             self.source_addresses,
         )
 
-    def add_destination_address(self, address):
+    def add_destination_address(self, address):  # noqa: D102
         self.add_address(
             address,
             self.destination_zone,
@@ -840,7 +840,7 @@ class NSPolicy(NetScreen):
             self.destination_addresses,
         )
 
-    def add_service(
+    def add_service(  # noqa: D102
         self,
         protocol,
         source_port=(1, 65535),
@@ -873,7 +873,7 @@ class NSPolicy(NetScreen):
             found = test_service
         self.services.append(found)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key):  # noqa: D105
         if key == "dst-address":
             return self.destination_addresses
         if key == "src-address":
@@ -882,7 +882,7 @@ class NSPolicy(NetScreen):
             return self.services
         raise KeyError
 
-    def output_crap(self):
+    def output_crap(self):  # noqa: D102
         for service in self.services:
             for src in self.source_addresses:
                 for dst in self.destination_addresses:
@@ -894,7 +894,7 @@ class NSPolicy(NetScreen):
                         service.output_crap(),
                     )
 
-    def output_human(self):
+    def output_human(self):  # noqa: D102
         source_addrs = []
         dest_addrs = []
         dest_serv = []
@@ -942,7 +942,7 @@ class NSPolicy(NetScreen):
         print("DESTINATIONS", dest_addrs)
         print("SERVICES", serv_hash)
 
-    def output_terms(self):
+    def output_terms(self):  # noqa: D102
         source_addrs = []
         dest_addrs = []
         dest_serv = []
@@ -978,7 +978,7 @@ class NSPolicy(NetScreen):
                 terms.append(term)
         return terms
 
-    def output(self):
+    def output(self):  # noqa: D102
         toret = []
         num_saddrs = len(self.source_addresses)
         num_daddrs = len(self.destination_addresses)

--- a/trigger/rancid.py
+++ b/trigger/rancid.py
@@ -93,7 +93,7 @@ def parse_rancid_file(rancid_root, filename=RANCID_DB_FILE, fields=None, delimit
 
     :param delimiter:
         (Optional) Field delimiter
-    """
+    """  # noqa: D205
     device_data = _parse_delimited_file(rancid_root, filename, delimiter)
     if not device_data:
         return None  # Always return None if there are no results
@@ -190,7 +190,7 @@ def parse_rancid_data(
 
     :param recurse_subdirs:
         Whether to recurse directories (e.g. multiple instances)
-    """
+    """  # noqa: D205
     if recurse_subdirs:
         subdirs = walk_rancid_subdirs(rancid_root, config_dirname, fields)
         metadata = gather_devices(subdirs, filename)
@@ -210,7 +210,7 @@ def parse_devices(metadata, parser):
 
     :param parser:
         A callabale used to create your objects
-    """
+    """  # noqa: D205
     # Two tees of `metadata` iterator, in case a TypeError is encountered, we
     # aren't losing the first item.
     md_original, md_backup = itertools.tee(metadata)
@@ -242,7 +242,7 @@ def gather_devices(subdir_data, rancid_db_file=RANCID_DB_FILE):
 
     :param rancid_db_file:
         If it's named other than ``router.db``
-    """
+    """  # noqa: D401, D205
     iters = []
     for files in subdir_data.values():
         # Only carry on if we find 'router.db' or it's equivalent
@@ -354,7 +354,7 @@ class RancidDevice(collections.namedtuple("RancidDevice", NETDEVICE_FIELDS)):
 
     __slots__ = ()
 
-    def __new__(cls, nodeName, manufacturer, deviceStatus=None, deviceType=None):
+    def __new__(cls, nodeName, manufacturer, deviceStatus=None, deviceType=None):  # noqa: D102
         return super(cls, RancidDevice).__new__(
             cls,
             nodeName,
@@ -401,7 +401,7 @@ class Rancid:
         Whether you want to recurse directories.
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, D107
         self,
         rancid_root,
         rancid_db_file=RANCID_DB_FILE,
@@ -425,13 +425,13 @@ class Rancid:
         self._populate()
 
     def _populate(self):
-        """Fired after init, does all the stuff to populate RANCID data."""
+        """Fired after init, does all the stuff to populate RANCID data."""  # noqa: D401
         self._populate_devices()
 
     def _populate_devices(self):
         """Read router.db or equivalent and populate ``devices`` dictionary
         with objects.
-        """
+        """  # noqa: D205
         metadata = parse_rancid_data(
             self.rancid_root,
             filename=self.rancid_db_file,
@@ -450,5 +450,5 @@ class Rancid:
     def _populate_data(self):
         """NYI - Maybe keep the other metadata but how?"""
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"Rancid({self.rancid_root!r}, recurse_subdirs={self.recurse_subdirs})"

--- a/trigger/tacacsrc.py
+++ b/trigger/tacacsrc.py
@@ -82,7 +82,7 @@ def get_device_password(device=None, tcrc=None):
 
     :param device:
         Optional `~trigger.tacacsrc.Tacacsrc` instance
-    """
+    """  # noqa: D205
     if tcrc is None:
         tcrc = Tacacsrc()
 
@@ -149,7 +149,7 @@ def update_credentials(device, username=None):
 
     :param device: Device or realm name to update
     :param username: Username for credentials
-    """
+    """  # noqa: D205
     tcrc = Tacacsrc()
     if tcrc.creds_updated:
         return None
@@ -177,7 +177,7 @@ def validate_credentials(creds=None):
     :param creds:
         A tuple of credentials.
 
-    """
+    """  # noqa: D205
     realm = settings.DEFAULT_REALM
 
     # If it isn't set or it's a string, or less than 1 or more than 3 items,
@@ -208,7 +208,7 @@ def validate_credentials(creds=None):
 
 
 def convert_tacacsrc():
-    """Converts old .tacacsrc to new .tacacsrc.gpg."""
+    """Converts old .tacacsrc to new .tacacsrc.gpg."""  # noqa: D401
     print("Converting old tacacsrc to new kind :)")
     tco = Tacacsrc(old=True)
     tcn = Tacacsrc(old=False, gen=True)
@@ -223,7 +223,7 @@ def _perl_unhex_old(c):
     "G".."Z" is not well-defined", says perlfunc(1).  Smash!
 
     This function can be safely removed once GPG is fully supported.
-    """
+    """  # noqa: D205
     if "a" <= c <= "z":
         return (ord(c) - ord("a") + 10) & 0xF
     if "A" <= c <= "Z":
@@ -235,7 +235,7 @@ def _perl_pack_Hstar_old(s):
     """Used with _perl_unhex_old(). Ghetto hack.
 
     This function can be safely removed once GPG is fully supported.
-    """
+    """  # noqa: D401
     r = ""
     while len(s) > 1:
         r += chr((_perl_unhex_old(s[0]) << 4) | _perl_unhex_old(s[1]))
@@ -255,7 +255,7 @@ class Tacacsrc:
 
     `*_old` functions should be removed after everyone is moved to the new
     system.
-    """
+    """  # noqa: D205
 
     def __init__(  # noqa: PLR0912
         self,
@@ -267,7 +267,7 @@ class Tacacsrc:
         a new file if one cannot be found on disk.
 
         If settings.USE_GPG_AUTH is enabled, tries to use GPG (.tacacsrc.gpg).
-        """
+        """  # noqa: D205
         self.file_name = tacacsrc_file
         self.use_gpg = use_gpg
         self.generate_new = generate_new
@@ -345,7 +345,7 @@ class Tacacsrc:
         """Of course, encrypting something in the filesystem using a key
         in the filesystem really doesn't buy much.  This is best referred
         to as obfuscation of the .tacacsrc.
-        """
+        """  # noqa: D205
         try:
             with Path(keyfile).open() as kf:
                 key = kf.readline().strip()
@@ -364,7 +364,7 @@ class Tacacsrc:
         return key
 
     def _parse_old(self):
-        """Parses .tacacsrc and returns dictionary of credentials."""
+        """Parses .tacacsrc and returns dictionary of credentials."""  # noqa: D401
         data = {}
         creds = {}
 
@@ -428,7 +428,7 @@ class Tacacsrc:
         :param creds: Dictionary of credentials keyed by realm
         :param realm: The realm to update within the creds dict
         :param user: (Optional) Username passed to prompt_credentials()
-        """
+        """  # noqa: D205
         creds[realm] = prompt_credentials(realm, user)
         log.msg("setting self.creds_updated flag", debug=True)
         self.creds_updated = True
@@ -436,7 +436,7 @@ class Tacacsrc:
         print(f"\nCredentials updated for user: {new_user!r}, device/realm: {realm!r}.")
 
     def _encrypt_old(self, s):
-        """Encodes using the old method. Adds a newline for you."""
+        """Encodes using the old method. Adds a newline for you."""  # noqa: D401
         # Ensure key and plaintext are bytes for cryptography library
         key = self.key if isinstance(self.key, bytes) else self.key.encode("latin-1")
         plaintext = s if isinstance(s, bytes) else s.encode("latin-1")
@@ -459,7 +459,7 @@ class Tacacsrc:
         ) + "\n"
 
     def _decrypt_old(self, s):
-        """Decodes using the old method. Strips newline for you."""
+        """Decodes using the old method. Strips newline for you."""  # noqa: D401
         # Ensure key is bytes for cryptography library
         key = self.key if isinstance(self.key, bytes) else self.key.encode("latin-1")
         des = TripleDES(key)
@@ -531,7 +531,7 @@ class Tacacsrc:
         self._update_perms()
 
     def write(self):
-        """Writes .tacacsrc(.gpg) using the accurate method (old vs. new)."""
+        """Writes .tacacsrc(.gpg) using the accurate method (old vs. new)."""  # noqa: D401
         if self.use_gpg:
             return self._write_new()
 
@@ -542,7 +542,7 @@ class Tacacsrc:
         Path(self.file_name).chmod(0o600)
 
     def _parse(self):
-        """Parses .tacacsrc.gpg and returns dictionary of credentials."""
+        """Parses .tacacsrc.gpg and returns dictionary of credentials."""  # noqa: D401
         data = {}
         creds = {}
         for line in self.rawdata:
@@ -572,7 +572,7 @@ class Tacacsrc:
         return creds
 
     def user_has_gpg(self):
-        """Checks if user has .gnupg directory and .tacacsrc.gpg file."""
+        """Checks if user has .gnupg directory and .tacacsrc.gpg file."""  # noqa: D401
         gpg_dir = Path(self.user_home) / ".gnupg"
         tacacsrc_gpg = Path(self.user_home) / ".tacacsrc.gpg"
 

--- a/trigger/twister.py
+++ b/trigger/twister.py
@@ -1,7 +1,7 @@
 """Login and basic command-line interaction support using the Twisted asynchronous
 I/O framework. The Trigger Twister is just like the Mersenne Twister, except
 not at all.
-"""
+"""  # noqa: D205
 
 import copy
 import fcntl
@@ -93,7 +93,7 @@ def is_awaiting_confirmation(prompt):
 
     :param prompt:
         The prompt string to check
-    """
+    """  # noqa: D401
     prompt = prompt.lower()
     matchlist = settings.CONTINUE_PROMPTS
     return any(prompt.endswith(match.lower()) for match in matchlist)
@@ -314,7 +314,7 @@ def handle_login_failure(failure):
 
     :param failure:
         A Twisted ``Failure`` instance
-    """
+    """  # noqa: D401
     global login_failed  # noqa: PLW0603
     login_failed = failure
 
@@ -411,7 +411,7 @@ def _choose_execute(device, force_cli=False):
 
     :param device:
         A `~trigger.netdevices.NetDevice` object.
-    """
+    """  # noqa: D205
     if device.is_ioslike():
         _execute = execute_ioslike
     elif device.is_netscaler():
@@ -498,7 +498,7 @@ def execute(  # noqa: PLR0913
         (Optional) Juniper-only: Force use of CLI instead of Junoscript.
 
     :returns: A Twisted ``Deferred`` object
-    """
+    """  # noqa: D205
     execute_func = _choose_execute(device, force_cli=force_cli)
     return execute_func(
         device=device,
@@ -529,7 +529,7 @@ def execute_generic_ssh(  # noqa: PLR0913
 
     Please see `~trigger.twister.execute` for a full description of the
     arguments and how this works.
-    """
+    """  # noqa: D205
     d = defer.Deferred()
 
     # Fallback to sane defaults if they aren't specified
@@ -612,7 +612,7 @@ def execute_junoscript(  # noqa: PLR0913
 
     Please see `~trigger.twister.execute` for a full description of the
     arguments and how this works.
-    """
+    """  # noqa: D205
     assert device.vendor == "juniper"  # noqa: S101
 
     channel_class = TriggerSSHJunoscriptChannel
@@ -651,7 +651,7 @@ def execute_ioslike(  # noqa: PLR0913
 
     Please see `~trigger.twister.execute` for a full description of the
     arguments and how this works.
-    """
+    """  # noqa: D205
     # Try SSH if it's available and enabled
     if device.can_ssh_async():
         log.msg(f"execute_ioslike: SSH ENABLED for {device.nodeName}")
@@ -810,7 +810,7 @@ def execute_netscreen(  # noqa: PLR0913
 
     Please see `~trigger.twister.execute` for a full description of the
     arguments and how this works.
-    """
+    """  # noqa: D205
     assert device.is_netscreen()  # noqa: S101
 
     # We live in a world where not every NetScreen device is local and can use
@@ -881,7 +881,7 @@ def execute_pica8(  # noqa: PLR0913
 
     Please see `~trigger.twister.execute` for a full description of the
     arguments and how this works.
-    """
+    """  # noqa: D205
     assert device.is_pica8()  # noqa: S101
 
     channel_class = TriggerSSHPica8Channel
@@ -908,7 +908,7 @@ def execute_pica8(  # noqa: PLR0913
 class TriggerClientFactory(protocol.ClientFactory):
     """Factory for all clients. Subclass me."""
 
-    def __init__(self, deferred, creds=None, init_commands=None):
+    def __init__(self, deferred, creds=None, init_commands=None):  # noqa: D107
         self.d = deferred
         self.creds = tacacsrc.validate_credentials(creds)
         self.results = []
@@ -936,7 +936,7 @@ class TriggerClientFactory(protocol.ClientFactory):
             log.msg(f"Got results: {self.results!r}")
             self.d.callback(self.results)
 
-    def stopFactory(self):
+    def stopFactory(self):  # noqa: D102
         # IF we're out of channels, shut it down!
         log.msg("All done!")
 
@@ -953,7 +953,7 @@ class TriggerClientFactory(protocol.ClientFactory):
                 protocol.write(next_init + "\r\n")
             self.initialized = True
 
-    def connection_success(self, conn, transport):
+    def connection_success(self, conn, transport):  # noqa: D102
         log.msg("Connection success.")
         self.conn = conn
         self.transport = transport
@@ -963,9 +963,9 @@ class TriggerClientFactory(protocol.ClientFactory):
 class TriggerSSHChannelFactory(TriggerClientFactory):
     """Intended to be used as a parent of automated SSH channels (e.g. Junoscript,
     NetScreen, NetScaler) to eliminate boiler plate in those subclasses.
-    """
+    """  # noqa: D205
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, D107
         self,
         deferred,
         commands,
@@ -1002,7 +1002,7 @@ class TriggerSSHChannelFactory(TriggerClientFactory):
         self.connection_class = connection_class
         TriggerClientFactory.__init__(self, deferred, creds)
 
-    def buildProtocol(self, addr):
+    def buildProtocol(self, addr):  # noqa: D102
         self.protocol = self.protocol()
         self.protocol.factory = self
         return self.protocol
@@ -1015,7 +1015,7 @@ class TriggerSSHPtyClientFactory(TriggerClientFactory):
     Use it to interact with the user and pass along commands.
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, D107
         self,
         deferred,
         action,
@@ -1063,7 +1063,7 @@ class TriggerSSHTransport(transport.SSHClientTransport):
     def dataReceived(self, data):
         """Explicity override version detection for edge cases where "SSH-"
         isn't on the first line of incoming data.
-        """
+        """  # noqa: D205
         # Store incoming data in a local buffer until we've detected the
         # presence of 'SSH-', then handover to default .dataReceived() for
         # version banner processing.
@@ -1106,7 +1106,7 @@ class TriggerSSHTransport(transport.SSHClientTransport):
     def connectionLost(self, reason):
         """Detect when the transport connection is lost, such as when the
         remote end closes the connection prematurely (hosts.allow, etc.).
-        """
+        """  # noqa: D205
         super().connectionLost(reason)
         log.msg(f"Transport connection lost: {reason.value}")
 
@@ -1146,7 +1146,7 @@ class TriggerSSHUserAuth(SSHUserAuthClient):
         This is most commonly the case with 'keyboard-interactive', which even
         when configured within self.preferredOrder, does not work using default
         getPassword() method.
-        """
+        """  # noqa: D205
         log.msg("Performing interactive authentication", debug=True)
         log.msg(f"Prompts: {prompts!r}", debug=True)
 
@@ -1178,7 +1178,7 @@ class TriggerSSHUserAuth(SSHUserAuthClient):
         call loseConnection().
 
         See the base docstring for the method signature.
-        """
+        """  # noqa: D401, D205
         canContinue, partial = common.getNS(packet)
         partial = ord(partial)
         log.msg(f"Previous method: {self.lastAuth!r} ", debug=True)
@@ -1201,7 +1201,7 @@ class TriggerSSHUserAuth(SSHUserAuthClient):
 
             @return: the comparison key for C{meth}.
             @rtype: C{int}
-            """
+            """  # noqa: D401, D205
             if meth in self.preferredOrder:
                 return self.preferredOrder.index(meth)
             # put the element at the end of the list.
@@ -1221,7 +1221,7 @@ class TriggerSSHUserAuth(SSHUserAuthClient):
         return self._cbUserauthFailure(None, iter(canContinue))
 
     def _cbUserauthFailure(self, result, iterator):
-        """Callback for ssh_USERAUTH_FAILURE."""
+        """Callback for ssh_USERAUTH_FAILURE."""  # noqa: D401
         if result:
             return None
         try:
@@ -1247,7 +1247,7 @@ class TriggerSSHConnection(SSHConnection):
     Optionally takes a list of commands that may be passed on.
     """
 
-    def __init__(self, commands=None, *args, **kwargs):
+    def __init__(self, commands=None, *args, **kwargs):  # noqa: D107
         super().__init__()
         self.commands = commands
 
@@ -1262,14 +1262,14 @@ class TriggerSSHConnection(SSHConnection):
         self._channelOpener()
 
     def _channelOpener(self):
-        """Calls ``self.channelOpen()``."""
+        """Calls ``self.channelOpen()``."""  # noqa: D401
         # Default behavior: Single channel/conn
         self.openChannel(self.channel_class(conn=self))
 
     def channelClosed(self, channel):
         """Forcefully close the transport connection when a channel closes
         connection. This is assuming only one channel is open.
-        """
+        """  # noqa: D401, D205
         log.msg("Forcefully closing transport connection!")
         self.transport.loseConnection()
 
@@ -1336,7 +1336,7 @@ class Interactor(protocol.Protocol):
     Intended for use as an action with pty_connect(). See gong for an example.
     """
 
-    def __init__(self, log_to=None):
+    def __init__(self, log_to=None):  # noqa: D107
         self._log_to = log_to
         self.enable_prompt = compile_prompt_pattern(settings.IOSLIKE_ENABLE_PAT)
         self.enabled = False
@@ -1357,7 +1357,7 @@ class Interactor(protocol.Protocol):
     def loseConnection(self):
         """Terminate the connection. Link this to the transport method of the same
         name.
-        """
+        """  # noqa: D205
         log.msg(f"[{self.device}] Forcefully closing transport connection")
         self.factory.transport.loseConnection()
 
@@ -1387,7 +1387,7 @@ class TriggerSSHPtyChannel(channel.SSHChannel):
     name = "session"
 
     def channelOpen(self, data):
-        """Setup the terminal when the channel opens."""
+        """Setup the terminal when the channel opens."""  # noqa: D401
         pr = session.packRequest_pty_req(
             settings.TERM_TYPE,
             self._get_window_size(),
@@ -1479,7 +1479,7 @@ class TriggerSSHChannelBase(channel.SSHChannel, TimeoutMixin):
         initialized.
 
         If the shell never establishes, this won't be called.
-        """
+        """  # noqa: D205
         log.msg(f"[{self.device}] Got channel request response!")
 
     def _ebShellOpen(self, reason):
@@ -1578,7 +1578,7 @@ class TriggerSSHChannelBase(channel.SSHChannel, TimeoutMixin):
     def loseConnection(self):
         """Terminate the connection. Link this to the transport method of the same
         name.
-        """
+        """  # noqa: D205
         log.msg(f"[{self.device}] Forcefully closing transport connection")
         self.conn.transport.loseConnection()
 
@@ -1588,7 +1588,7 @@ class TriggerSSHChannelBase(channel.SSHChannel, TimeoutMixin):
         self.factory.err = exceptions.CommandTimeout("Timed out while sending commands")
         self.loseConnection()
 
-    def request_exit_status(self, data):
+    def request_exit_status(self, data):  # noqa: D102
         status = struct.unpack(">L", data)[0]
         log.msg(f"[{self.device}] Exit status: {status}")
 
@@ -1600,7 +1600,7 @@ class TriggerSSHGenericChannel(TriggerSSHChannelBase):
     Currently A10, Cisco, Brocade, NetScreen can simply use this. Nice!
 
     Before you create your own subclass, see if you can't use me as-is!
-    """
+    """  # noqa: D205
 
 
 class TriggerSSHAsyncPtyChannel(TriggerSSHChannelBase):
@@ -1612,9 +1612,9 @@ class TriggerSSHAsyncPtyChannel(TriggerSSHChannelBase):
 
     This is distinctly different from ~trigger.twister.TriggerSSHPtyChannel`
     which is intended for interactive end-user sessions.
-    """
+    """  # noqa: D205
 
-    def channelOpen(self, data):
+    def channelOpen(self, data):  # noqa: D102
         self._setup_channelOpen()
 
         # Request a pty even tho we are not actually using one.
@@ -1634,7 +1634,7 @@ class TriggerSSHCommandChannel(TriggerSSHChannelBase):
     individual channel which feeds its result back to the factory.
     """
 
-    def __init__(self, command, *args, **kwargs):
+    def __init__(self, command, *args, **kwargs):  # noqa: D107
         super().__init__(*args, **kwargs)
         self.command = command
         self.result = None
@@ -1656,11 +1656,11 @@ class TriggerSSHCommandChannel(TriggerSSHChannelBase):
     def _ebShellOpen(self, reason):
         log.msg(f"[{self.device}] CHANNEL {reason}: Channel request failed: {self.id}")
 
-    def dataReceived(self, bytes):
+    def dataReceived(self, bytes):  # noqa: D102
         self.data += bytes
         log.msg(f"[{self.device}] BYTES RECV: {bytes!r}")
 
-    def eofReceived(self):
+    def eofReceived(self):  # noqa: D102
         log.msg(f"[{self.device}] CHANNEL {self.id}: EOF received.")
         result = self.data
 
@@ -1681,7 +1681,7 @@ class TriggerSSHCommandChannel(TriggerSSHChannelBase):
         log.msg(f"[{self.device}] CHANNEL {self.id}: sending next command!")
         self.conn.send_command()
 
-    def closeReceived(self):
+    def closeReceived(self):  # noqa: D102
         log.msg(f"[{self.device}] CHANNEL {self.id}: Close received.")
         self.loseConnection()
 
@@ -1690,7 +1690,7 @@ class TriggerSSHCommandChannel(TriggerSSHChannelBase):
         log.msg(f"[{self.device}] LOSING CHANNEL CONNECTION")
         channel.SSHChannel.loseConnection(self)
 
-    def closed(self):
+    def closed(self):  # noqa: D102
         log.msg(f"[{self.device}] Channel {self.id} closed")
         log.msg(f"[{self.device}] CONN CHANNELS: {len(self.conn.channels)}")
 
@@ -1699,7 +1699,7 @@ class TriggerSSHCommandChannel(TriggerSSHChannelBase):
             log.msg(f"[{self.device}] RESULTS MATCHES COMMANDS SENT.")
             self.conn.transport.loseConnection()
 
-    def request_exit_status(self, data):
+    def request_exit_status(self, data):  # noqa: D102
         exitStatus = int(struct.unpack(">L", data)[0])
         log.msg(f"[{self.device}] Exit status: {exitStatus}")
 
@@ -1711,7 +1711,7 @@ class TriggerSSHJunoscriptChannel(TriggerSSHChannelBase):
     This completely assumes that we are the only channel in the factory (a
     TriggerJunoscriptFactory) and walks all the way back up to the factory for
     its arguments.
-    """
+    """  # noqa: D205
 
     def channelOpen(self, data):
         """Do this when channel opens."""
@@ -1826,7 +1826,7 @@ class TriggerSSHPica8Channel(TriggerSSHAsyncPtyChannel):
     def _setup_commanditer(self, commands=None):
         """Munge our list of commands and overload self.commanditer to append
         " | no-more" to any "show" commands.
-        """
+        """  # noqa: D205
         if commands is None:
             commands = self.factory.commands
         new_commands = []
@@ -1840,7 +1840,7 @@ class TriggerSSHPica8Channel(TriggerSSHAsyncPtyChannel):
     def channelOpen(self, data):
         """Override channel open, which is where commanditer is setup in the
         base class.
-        """
+        """  # noqa: D205
         super().channelOpen(data)
         self._setup_commanditer()  # Replace self.commanditer with our version
 
@@ -1859,7 +1859,7 @@ class IncrementalXMLTreeBuilder(TreeBuilder):
     Note: XMLTreeBuilder was renamed to TreeBuilder in Python 3.
     """
 
-    def __init__(self, callback, *args, **kwargs):
+    def __init__(self, callback, *args, **kwargs):  # noqa: D107
         self._endhandler = callback
         TreeBuilder.__init__(self, *args, **kwargs)
 
@@ -1876,7 +1876,7 @@ class IncrementalXMLTreeBuilder(TreeBuilder):
 class TriggerTelnetClientFactory(TriggerClientFactory):
     """Factory for a telnet connection."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, D107
         self,
         deferred,
         action,
@@ -1898,9 +1898,9 @@ class TriggerTelnetClientFactory(TriggerClientFactory):
 class TriggerTelnet(telnet.Telnet, telnet.ProtocolTransportMixin, TimeoutMixin):
     """Telnet-based session login state machine. Primarily used by IOS-like type
     devices.
-    """
+    """  # noqa: D205
 
-    def __init__(self, timeout=settings.TELNET_TIMEOUT):
+    def __init__(self, timeout=settings.TELNET_TIMEOUT):  # noqa: D107
         self.protocol = telnet.TelnetProtocol()
         self.waiting_for = [
             ("Username: ", self.state_username),  # Most
@@ -1920,7 +1920,7 @@ class TriggerTelnet(telnet.Telnet, telnet.ProtocolTransportMixin, TimeoutMixin):
         enabled already (e.g. ECHO). (Ref: http://bit.ly/wkFZFg) For some
         reason Arista Networks hardware is the only vendor that needs this
         method right now.
-        """
+        """  # noqa: D205
         log.msg(f"enableRemote option: {option!r}")
         return True
 
@@ -1963,7 +1963,7 @@ class TriggerTelnet(telnet.Telnet, telnet.ProtocolTransportMixin, TimeoutMixin):
     def state_logged_in(self):
         """Once we're logged in, exit state machine and pass control to the
         action.
-        """
+        """  # noqa: D205
         self.setTimeout(None)
         data = self.data.lstrip("\n")
         log.msg(f"[{self.host}] state_logged_in, DATA: {data!r}")
@@ -1986,7 +1986,7 @@ class TriggerTelnet(telnet.Telnet, telnet.ProtocolTransportMixin, TimeoutMixin):
         """Special Foundry breakage because they don't do auto-enable from
         TACACS by default. Use 'aaa authentication login privilege-mode'.
         Also, why no space after the Password: prompt here?
-        """
+        """  # noqa: D401, D205
         log.msg(f"[{self.host}] ENABLE: Sending command: enable")
         self.write("enable\n")
         self.waiting_for = [
@@ -2034,7 +2034,7 @@ class TriggerTelnet(telnet.Telnet, telnet.ProtocolTransportMixin, TimeoutMixin):
     def state_percent_error(self):
         """Found a % error message. Don't return immediately because we
         don't have the error text yet.
-        """
+        """  # noqa: D205
         self.waiting_for = [("\n", self.state_raise_error)]
 
     def state_raise_error(self):
@@ -2058,7 +2058,7 @@ class IoslikeSendExpect(protocol.Protocol, TimeoutMixin):
     one errors. Wait for a prompt after each.
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, D107
         self,
         device,
         commands,

--- a/trigger/twister2.py
+++ b/trigger/twister2.py
@@ -1,7 +1,7 @@
 """Login and basic command-line interaction support using the Twisted asynchronous
 I/O framework. The Trigger Twister is just like the Mersenne Twister, except
 not at all.
-"""
+"""  # noqa: D205
 
 import fcntl
 import os
@@ -72,7 +72,7 @@ class SSHSessionAddress:
     We load command with a null string as Cisco device's typically do not support bash!
     """
 
-    def __init__(self, server, username, command):
+    def __init__(self, server, username, command):  # noqa: D107
         self.server = server
         self.username = username
         self.command = command
@@ -140,11 +140,11 @@ class _TriggerShellChannel(SSHChannel):
         return struct.unpack("4H", winsz)
 
     def _execFailure(self, reason):
-        """Callback for when the exec command fails."""
+        """Callback for when the exec command fails."""  # noqa: D401
         self._commandConnected.errback(reason)
 
     def _execSuccess(self, ignored):
-        """Callback for when the exec command succees."""
+        """Callback for when the exec command succees."""  # noqa: D401
         self._protocol = self._protocolFactory.buildProtocol(
             SSHSessionAddress(
                 self.conn.transport.transport.getPeer(),
@@ -157,7 +157,7 @@ class _TriggerShellChannel(SSHChannel):
         self._commandConnected.callback(self._protocol)
 
     def _bind_protocol_data(self):
-        """Helper method to bind protocol related attributes to the channel."""
+        """Helper method to bind protocol related attributes to the channel."""  # noqa: D401
         # This was a string before, now it's a NetDevice.
         self._protocol.device = self.conn.transport.creator.device or None
 
@@ -174,7 +174,7 @@ class _TriggerShellChannel(SSHChannel):
         """Callback for when data is received.
 
         Once data is received in the channel we defer to the protocol level dataReceived method.
-        """
+        """  # noqa: D401
         self._protocol.dataReceived(data)
 
 
@@ -194,7 +194,7 @@ class _TriggerUserAuth(_UserAuth):
         This is most commonly the case with 'keyboard-interactive', which even
         when configured within self.preferredOrder, does not work using default
         getPassword() method.
-        """
+        """  # noqa: D205
         log.msg("Performing interactive authentication", debug=True)
         log.msg(f"Prompts: {prompts!r}", debug=True)
 
@@ -219,7 +219,7 @@ class _TriggerUserAuth(_UserAuth):
         sendDisconnect(), we raise a `~trigger.exceptions.LoginFailure` and
         call loseConnection().
         See the base docstring for the method signature.
-        """
+        """  # noqa: D401, D205
         canContinue, partial = common.getNS(packet)
         partial = ord(partial)
         log.msg(f"Previous method: {self.lastAuth!r} ", debug=True)
@@ -240,7 +240,7 @@ class _TriggerUserAuth(_UserAuth):
             @type meth: C{str}
             @return: the comparison key for C{meth}.
             @rtype: C{int}.
-            """
+            """  # noqa: D401, D205
             if meth in self.preferredOrder:
                 return self.preferredOrder.index(meth)
             # put the element at the end of the list.
@@ -260,7 +260,7 @@ class _TriggerUserAuth(_UserAuth):
         return self._cbUserauthFailure(None, iter(canContinue))
 
     def _cbUserauthFailure(self, result, iterator):
-        """Callback for ssh_USERAUTH_FAILURE."""
+        """Callback for ssh_USERAUTH_FAILURE."""  # noqa: D401
         if result:
             return None
         try:
@@ -291,7 +291,7 @@ class _TriggerCommandTransport(_CommandTransport):
     def dataReceived(self, data):
         """Explicity override version detection for edge cases where "SSH-"
         isn't on the first line of incoming data.
-        """
+        """  # noqa: D205
         # Store incoming data in a local buffer until we've detected the
         # presence of 'SSH-', then handover to default .dataReceived() for
         # version banner processing.
@@ -346,7 +346,7 @@ class _TriggerSessionTransport(_TriggerCommandTransport):
 class _NewTriggerConnectionHelperBase(_NewConnectionHelper):
     """Return object used for establishing an async session rather than executing
     a single command.
-    """
+    """  # noqa: D205
 
     def __init__(  # noqa: PLR0913
         self,
@@ -387,7 +387,7 @@ class _NewTriggerConnectionHelperBase(_NewConnectionHelper):
 class TriggerEndpointClientFactory(protocol.Factory):
     """Factory for all clients. Subclass me."""
 
-    def __init__(self, creds=None, init_commands=None):
+    def __init__(self, creds=None, init_commands=None):  # noqa: D107
         self.creds = tacacsrc.validate_credentials(creds)
         self.results = []
         self.err = None
@@ -414,7 +414,7 @@ class TriggerEndpointClientFactory(protocol.Factory):
             log.msg(f"Got results: {self.results!r}")
             self.d.callback(self.results)
 
-    def stopFactory(self):
+    def stopFactory(self):  # noqa: D102
         # IF we're out of channels, shut it down!
         log.msg("All done!")
 
@@ -431,7 +431,7 @@ class TriggerEndpointClientFactory(protocol.Factory):
                 protocol.write(next_init + "\r\n")
             self.initialized = True
 
-    def connection_success(self, conn, transport):
+    def connection_success(self, conn, transport):  # noqa: D102
         log.msg("Connection success.")
         self.conn = conn
         self.transport = transport
@@ -445,7 +445,7 @@ class TriggerSSHShellClientEndpointBase(SSHCommandClientEndpoint):
     """
 
     @classmethod
-    def newConnection(  # noqa: PLR0913
+    def newConnection(  # noqa: PLR0913, D102
         cls,
         reactor,
         username,
@@ -476,7 +476,7 @@ class TriggerSSHShellClientEndpointBase(SSHCommandClientEndpoint):
         helper = _ExistingConnectionHelper(connection)
         return cls(helper)
 
-    def __init__(self, creator):
+    def __init__(self, creator):  # noqa: D107
         self._creator = creator
 
     def _executeCommand(  # noqa: PLR0913
@@ -534,7 +534,7 @@ class TriggerSSHShellClientEndpointBase(SSHCommandClientEndpoint):
 
         :param factory: Trigger factory responsible for setting up connection
         :type factory: `~trigger.twister2.TriggerEndpointClientFactory`
-        """
+        """  # noqa: D401
         d = self._creator.secureConnection()
         d.addCallback(
             self._executeCommand,
@@ -556,7 +556,7 @@ class IoslikeSendExpect(protocol.Protocol, TimeoutMixin):
     one errors. Wait for a prompt after each.
     """
 
-    def __init__(self):
+    def __init__(self):  # noqa: D107
         self.device = None
         self.commands = []
         self.commanditer = iter(self.commands)
@@ -579,7 +579,7 @@ class IoslikeSendExpect(protocol.Protocol, TimeoutMixin):
         self.data = ""
         log.msg(f"[{self.device}] connectionMade, data: {self.data!r}")
 
-    def connectionLost(self, reason):
+    def connectionLost(self, reason):  # noqa: D102
         self.finished.callback(None)
 
         # Don't call _send_next, since we expect to see a prompt, which

--- a/trigger/utils/__init__.py
+++ b/trigger/utils/__init__.py
@@ -20,7 +20,7 @@ def crypt_md5(passwd):
 
     :param passwd:
         Password string to be encrypted
-    """
+    """  # noqa: D401
     import platform
 
     if platform.system() == "Linux":
@@ -74,7 +74,7 @@ NodePort = namedtuple("HostPort", "nodeName nodePort")
 def parse_node_port(nodeport, delimiter=":"):
     """Parse a string in format 'hostname' or 'hostname:port'  and return them
     as a 2-tuple.
-    """
+    """  # noqa: D205
     node, _, port = nodeport.partition(delimiter)
     port = int(port) if port.isdigit() else None
 

--- a/trigger/utils/cli.py
+++ b/trigger/utils/cli.py
@@ -1,6 +1,6 @@
 """Command-line interface utilities for Trigger tools. Intended for re-usable
 pieces of code like user prompts, that don't fit in other utils modules.
-"""
+"""  # noqa: D205
 
 __author__ = "Jathan McCollum"
 __maintainer__ = "Jathan McCollum"
@@ -124,7 +124,7 @@ def print_severed_head():
     production-impacting network outages caused by fat-fingered ACL changes.
 
     Thanks to Jeff Sullivan for this best error message ever.
-    """
+    """  # noqa: D401, D205
     print(r"""
 
                                                                 _( (~\
@@ -173,7 +173,7 @@ def pretty_time(t):
     2011-07-20 04:13:00-05:00
     >>> print pretty_time(t)
     tomorrow 02:13 PDT
-    """
+    """  # noqa: D205
     from trigger.conf import settings
 
     localzone = timezone(os.environ.get("TZ", settings.BOUNCE_DEFAULT_TZ))
@@ -211,7 +211,7 @@ def min_sec(secs):
     >>> finish = time.time()
     >>> min_sec(finish - start)
     '0:11'
-    """
+    """  # noqa: D401
     secs = int(secs)
     return "%d:%02d" % (secs / 60, secs % 60)  # noqa: UP031
 
@@ -223,7 +223,7 @@ def setup_tty_for_pty(func):
 
     :param func:
         The callable to run after the tty is ready, such as ``reactor.run``
-    """
+    """  # noqa: D401, D205
     # Preserve original tty settings
     stdin_fileno = sys.stdin.fileno()
     old_ttyattr = tty.tcgetattr(stdin_fileno)
@@ -255,7 +255,7 @@ def update_password_and_reconnect(hostname):
     device.
 
     :param hostname: Hostname of the device to connect to.
-    """
+    """  # noqa: D205
     if yesno(
         "Authentication failed, would you like to update your password?",
         default=True,
@@ -294,7 +294,7 @@ class NullDevice:
         3 - this will print to SDTDOUT
     """
 
-    def write(self, s):
+    def write(self, s):  # noqa: D102
         pass
 
 
@@ -309,9 +309,9 @@ class Whirlygig:
     Example::
 
         >>> Whirlygig("Doing stuff:", "Done.", 12).run()
-    """
+    """  # noqa: D205
 
-    def __init__(self, start_msg="", done_msg="", max=100):
+    def __init__(self, start_msg="", done_msg="", max=100):  # noqa: D107
         self.unbuff = os.fdopen(sys.stdout.fileno(), "w", 0)
         self.start_msg = start_msg
         self.done_msg = done_msg
@@ -320,14 +320,14 @@ class Whirlygig:
         self.whirl = self.whirlygig[:]
         self.first = False
 
-    def do_whirl(self, whirl):
+    def do_whirl(self, whirl):  # noqa: D102
         if not self.first:
             self.unbuff.write(self.start_msg + "  ")
             self.first = True
         self.unbuff.write(f"\b{whirl.pop(0)}")
 
     def run(self):
-        """Executes the whirlygig!"""
+        """Executes the whirlygig!"""  # noqa: D401
         cnt = 1
         while cnt <= self.max:
             try:

--- a/trigger/utils/network.py
+++ b/trigger/utils/network.py
@@ -39,7 +39,7 @@ def ping(host, count=1, timeout=5):
     True
     >>> network.ping('192.168.199.253')
     False
-    """
+    """  # noqa: D401
     ping_command = "ping -q -c%d -W%d %s" % (count, timeout, host)  # noqa: UP031
     status = None
     with Path(os.devnull).open("w") as devnull_fd:
@@ -148,5 +148,5 @@ def address_is_internal(ip):
 
     >>> address_is_internal('1.1.1.1')
     False
-    """
+    """  # noqa: D401, D205
     return any(ip in i for i in settings.INTERNAL_NETWORKS)

--- a/trigger/utils/notifications/core.py
+++ b/trigger/utils/notifications/core.py
@@ -47,7 +47,7 @@ def send_email(  # noqa: PLR0913
 
     :param ssl:
         (Optional) Use SMTP_SSL for secure communication
-    """
+    """  # noqa: D401
     import smtplib
 
     for email in addresses:
@@ -70,5 +70,5 @@ def send_notification(*args, **kwargs):
 
     This relies on handlers to be definied within
     ``settings.NOTIFICATION_HANDLERS``.
-    """
+    """  # noqa: D401, D205
     return handlers.notify(*args, **kwargs)

--- a/trigger/utils/notifications/events.py
+++ b/trigger/utils/notifications/events.py
@@ -39,7 +39,7 @@ class Event:
 
     required_args = ()
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs):  # noqa: D107
         self.__dict__.update(kwargs)  # Brute force wins!
         local_vars = self.__dict__
         for var, value in local_vars.items():
@@ -47,10 +47,10 @@ class Event:
                 msg = f"`{var}` is a required argument"
                 raise SyntaxError(msg)
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return f"<{self.__class__.__name__}>"
 
-    def handle(self):
+    def handle(self):  # noqa: D102
         msg = "Define me in your subclass!"
         raise NotImplementedError(msg)
 
@@ -93,7 +93,7 @@ class Notification(Event):
     }
     default_sender = settings.NOTIFICATION_SENDER
 
-    def __init__(
+    def __init__(  # noqa: D107
         self,
         title=None,
         message=None,
@@ -136,7 +136,7 @@ class EmailEvent(Notification):
     }
     mailhost = "localhost"
 
-    def handle(self):
+    def handle(self):  # noqa: D102
         from trigger.utils.notifications import send_email
 
         try:

--- a/trigger/utils/notifications/handlers.py
+++ b/trigger/utils/notifications/handlers.py
@@ -58,7 +58,7 @@ def _register_handlers():
     register them internally.
 
     Any built-in event handlers need to be defined above this function.
-    """
+    """  # noqa: D205
     global HANDLERS_REGISTERED  # noqa: PLW0603
     from trigger.conf import settings
 

--- a/trigger/utils/rcs.py
+++ b/trigger/utils/rcs.py
@@ -52,7 +52,7 @@ class RCS:
     first commit
     """
 
-    def __init__(self, filename, create=True):
+    def __init__(self, filename, create=True):  # noqa: D107
         self.locked = False
         self.filename = filename
 
@@ -78,7 +78,7 @@ class RCS:
 
         >>> rcs.checkin('This is my commit message')
         True
-        """
+        """  # noqa: D205
         if initial:
             cmd = f'ci -m"first commit" -t- -i {self.filename}'
         else:
@@ -98,7 +98,7 @@ class RCS:
 
         >>> rcs.lock()
         True
-        """
+        """  # noqa: D205
         cmd = f"co -f -l {self.filename}"
         status, output = commands.getstatusoutput(cmd)  # noqa: S605
 
@@ -159,7 +159,7 @@ class RCS:
         return True
 
     def log(self):
-        """Returns the RCS log as a string (see above)."""
+        """Returns the RCS log as a string (see above)."""  # noqa: D401
         cmd = f"rlog {self.filename} 2>&1"
         status, output = commands.getstatusoutput(cmd)  # noqa: S605
 

--- a/trigger/utils/templates.py
+++ b/trigger/utils/templates.py
@@ -52,7 +52,7 @@ def load_cmd_template(cmd, dev_type=None):
     :param cmd: CLI command to load template.
     :type  cmd: str
     :returns: String template path
-    """
+    """  # noqa: D205
     try:
         with Path(get_template_path(cmd, dev_type=dev_type)).open("rb") as f:
             return textfsm.TextFSM(f)
@@ -61,7 +61,7 @@ def load_cmd_template(cmd, dev_type=None):
 
 
 def get_textfsm_object(re_table, cli_output):
-    """Returns structure object from TextFSM data."""
+    """Returns structure object from TextFSM data."""  # noqa: D401
     from collections import defaultdict
 
     rv = defaultdict(list)


### PR DESCRIPTION
## Summary
- **D102** (undocumented-public-method): 127 noqa suppressions
- **D105** (undocumented-magic-method): 90 noqa suppressions
- **D107** (undocumented-public-init): 54 noqa suppressions
- **D205** (missing-blank-line-after-summary): 181 noqa suppressions
- **D401** (non-imperative-mood): 117 noqa suppressions (uses `extend-select` since google convention excludes D401)
- **F405** (undefined-local-with-import-star-usage): 154 noqa suppressions

This is the final cleanup round. Only `COM812` and `E501` remain as permanent ignores (both are formatter conflicts per ruff docs). Globally ignored rules reduced from 34 (original) to 2.

## Test plan
- [x] `ruff check trigger/ tests/ configs/` passes
- [x] `ruff format --check trigger/ tests/ configs/` passes
- [x] `pytest` — 170 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily lint-configuration and comment-only (`# noqa`/docstring) changes with no intended runtime behavior changes; risk is limited to accidental masking of real issues via overly broad suppressions.
> 
> **Overview**
> Enables stricter Ruff linting by removing global ignores for `D102`, `D105`, `D107`, `D205`, `D401`, and `F405`, and explicitly re-enabling `D401` via `extend-select` in `pyproject.toml`.
> 
> Updates many modules (notably `trigger/acl/*`, CLI entrypoints under `trigger/bin/`, `trigger/netdevices/*`, and contrib/XMLRPC tooling) to comply by adding localized `# noqa` suppressions on docstrings, magic methods, and star-import usages, plus small docstring formatting/wording adjustments to satisfy the new checks. Also applies a couple of `# noqa: F405` annotations in tests where star imports are used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 163a48439aa6bb3833b9d2997f719d7ef42a0faa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->