### PR TITLE
Remove unnecessary coding: utf-8 declarations

### DIFF
--- a/tools/prepend_acl_dot
+++ b/tools/prepend_acl_dot
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 parsing_check - Determines if ACL passes parsing check

--- a/twisted/plugins/trigger_xmlrpc.py
+++ b/twisted/plugins/trigger_xmlrpc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 # trigger_xmlrpc.py - Twisted twistd server plugin for Trigger
 """


### PR DESCRIPTION
## Summary
- Remove `# -*- coding: utf-8 -*-` lines from `twisted/plugins/trigger_xmlrpc.py` and `tools/prepend_acl_dot`
- UTF-8 is the default source encoding in Python 3, making these declarations redundant

## Test plan
- [x] Verified only 2 files in the codebase had this declaration
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only removes `# -*- coding: utf-8 -*-` headers from two Python files; no runtime logic changes expected.
> 
> **Overview**
> Removes the `# -*- coding: utf-8 -*-` source-encoding header from `tools/prepend_acl_dot` and `twisted/plugins/trigger_xmlrpc.py`, relying on Python 3’s default UTF-8 encoding. No functional or behavioral changes beyond the file headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96575fdcfe69d64c8bd2b27da20fd5bca5bd7241. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->