### PR TITLE
ci: fix release-preview workflow changelog and comment spam

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -30,49 +30,82 @@ jobs:
           version: "0.10.0"
           enable-cache: true
 
-      - name: Install dependencies
+      - name: Compute version and changelog
+        id: version
         run: |
           uv tool install python-semantic-release
 
-      - name: Get next version
-        id: version
-        run: |
-          # Run semantic-release in dry-run mode to get next version
+          # Get next version
           NEXT_VERSION=$(python-semantic-release version --print || echo "No version change")
           echo "next_version=${NEXT_VERSION}" >> $GITHUB_OUTPUT
 
-          # Get changelog preview
-          python-semantic-release changelog --unreleased > /tmp/changelog.md || echo "No changes" > /tmp/changelog.md
+          # Generate changelog: delete the existing file so PSR regenerates
+          # from scratch (produces a proper "## Unreleased" section).
+          rm -f CHANGELOG.md
+          python-semantic-release changelog
 
-      - name: Comment PR
+          # Extract the Unreleased section (strip the heading itself)
+          CHANGELOG=$(sed -n '/^## Unreleased/,/^## v/{/^## Unreleased/d;/^## v/d;p}' CHANGELOG.md)
+          if [ -z "$CHANGELOG" ]; then
+            CHANGELOG="No changes detected."
+          fi
+
+          # Write to file for the next step (multi-line safe)
+          echo "$CHANGELOG" > /tmp/changelog-preview.md
+
+      - name: Upsert PR comment
         uses: actions/github-script@v7
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
         with:
           script: |
             const fs = require('fs');
-            const nextVersion = '${{ steps.version.outputs.next_version }}';
-            const changelog = fs.readFileSync('/tmp/changelog.md', 'utf8');
+            const marker = '<!-- release-preview-bot -->';
+            const nextVersion = process.env.NEXT_VERSION;
+            const changelog = fs.readFileSync('/tmp/changelog-preview.md', 'utf8').trim();
 
-            const body = `## 🚀 Release Preview
+            const body = [
+              marker,
+              '## Release Preview',
+              '',
+              `**Next Version:** \`${nextVersion}\``,
+              '',
+              '### Changelog Preview',
+              '',
+              changelog,
+              '',
+              '---',
+              '',
+              '*This version will be automatically released when this PR is merged to main.*',
+              '',
+              '**Reminder:** Use conventional commits:',
+              '- `fix:` → Patch release (2.0.0 → 2.0.1)',
+              '- `feat:` → Minor release (2.0.0 → 2.1.0)',
+              '- `feat!:` or `BREAKING CHANGE:` → Major release (2.0.0 → 3.0.0)',
+            ].join('\n');
 
-            **Next Version:** \`${nextVersion}\`
-
-            ### Changelog Preview
-
-            ${changelog}
-
-            ---
-
-            *This version will be automatically released when this PR is merged to main.*
-
-            **Reminder:** Use conventional commits:
-            - \`fix:\` → Patch release (2.0.0 → 2.0.1)
-            - \`feat:\` → Minor release (2.0.0 → 2.1.0)
-            - \`feat!:\` or \`BREAKING CHANGE:\` → Major release (2.0.0 → 3.0.0)
-            `;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
+            // Look for an existing comment with our marker (paginate to search all)
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: body
+              issue_number: context.issue.number,
             });
+            const existing = comments.find(c => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+              console.log(`Updated existing comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+              console.log('Created new comment');
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Python Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9
+        uses: python-semantic-release/python-semantic-release@v10
         with:
           github_token: ${{ secrets.RELEASE_TOKEN }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,8 @@ minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
 
 [tool.semantic_release.changelog]
+
+[tool.semantic_release.changelog.default_templates]
 changelog_file = "CHANGELOG.md"
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
## Summary

- **Fix changelog**: Replace broken `changelog --unreleased` (no such option in PSR v10) with delete-and-regenerate approach — deletes `CHANGELOG.md` so PSR rebuilds it with an `## Unreleased` section, then extracts that section with `sed`
- **Fix comment spam**: Upsert PR comments using a `<!-- release-preview-bot -->` HTML marker instead of creating a new comment on every push
- **Fix script injection**: Pass version via `env` block + `process.env` instead of direct `${{ }}` interpolation in the github-script JS
- **Fix deprecation**: Move `changelog_file` to `[tool.semantic_release.changelog.default_templates]` per PSR v10
- **Upgrade release workflow**: Bump `python-semantic-release/python-semantic-release` from `@v9` to `@v10`

Ported from jathanism/nsot#67.

## Test plan

- [ ] Open a test PR with a conventional commit and verify the release-preview comment appears with correct version and changelog entries
- [ ] Push another commit to the same PR and verify the existing comment is updated (not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/release automation and semantic-release configuration; risk is mainly incorrect version/changelog output or comment update behavior, not runtime code.
> 
> **Overview**
> Fixes the Release Preview workflow to correctly compute the next version and generate an *Unreleased* changelog section with python-semantic-release by regenerating `CHANGELOG.md` and extracting the `## Unreleased` block for the PR comment.
> 
> Updates the PR commenting step to **upsert** a single comment (using a `<!-- release-preview-bot -->` marker) instead of spamming new ones, and passes `NEXT_VERSION` via `env` rather than direct `${{ }}` interpolation.
> 
> Upgrades the release workflow to `python-semantic-release@v10` and adjusts `pyproject.toml` semantic-release config so `changelog_file` is read from `[tool.semantic_release.changelog.default_templates]` (v10-compatible).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a953ce23c752e72a5043950720bb840d257e1b72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->